### PR TITLE
Add lazy detail queries with Jikan retry handling

### DIFF
--- a/src/components/FullAnime/FullAnime.jsx
+++ b/src/components/FullAnime/FullAnime.jsx
@@ -11,7 +11,13 @@ import playButton from "../../assets/images/playButton.svg";
 import "./FullAnime.scss";
 import AOS from "aos";
 import "aos/dist/aos.css";
-import { useGetAnimeCharactersQuery, useGetAnimeEpisodesQuery, useGetAnimePicturesQuery, useGetAnimeReviewsQuery, useGetFullAnimeQuery } from "../../features/apiSlice";
+import {
+  useGetAnimeEpisodesQuery,
+  useGetAnimePicturesQuery,
+  useGetFullAnimeQuery,
+  useLazyGetAnimeCharactersQuery,
+  useLazyGetAnimeReviewsQuery,
+} from "../../features/apiSlice";
 
 const swiperBreakpoints = {
   320: {
@@ -47,34 +53,42 @@ const FullAnime = () => {
     isError: fullAnimeError,
     refetch: refetchFullAnime,
   } = useGetFullAnimeQuery(id)
+  const anime = fullAnimeData?.data;
+  const canLoadAnimeSecondary = Boolean(id && anime);
   const {
     data: animePictures,
     isLoading: animePicturesLoading,
     isFetching: animePicturesFetching,
     isError: animePicturesError,
     refetch: refetchAnimePictures,
-  } = useGetAnimePicturesQuery(id)
+  } = useGetAnimePicturesQuery(id, { skip: !canLoadAnimeSecondary })
   const {
     data: animeEpisodes,
     isLoading: animeEpisodesLoading,
     isFetching: animeEpisodesFetching,
     isError: animeEpisodesError,
     refetch: refetchAnimeEpisodes,
-  } = useGetAnimeEpisodesQuery(id)
-  const {
-    data: animeCharacters,
-    isLoading: animeCharactersLoading,
-    isFetching: animeCharactersFetching,
-    isError: animeCharactersError,
-    refetch: refetchAnimeCharacters,
-  } = useGetAnimeCharactersQuery(id)
-  const {
-    data: animeReviews,
-    isLoading: animeReviewsLoading,
-    isFetching: animeReviewsFetching,
-    isError: animeReviewsError,
-    refetch: refetchAnimeReviews,
-  } = useGetAnimeReviewsQuery(id)
+  } = useGetAnimeEpisodesQuery(id, { skip: !canLoadAnimeSecondary })
+  const [
+    triggerAnimeCharacters,
+    {
+      data: animeCharacters,
+      isLoading: animeCharactersLoading,
+      isFetching: animeCharactersFetching,
+      isUninitialized: animeCharactersUninitialized,
+      isError: animeCharactersError,
+    },
+  ] = useLazyGetAnimeCharactersQuery()
+  const [
+    triggerAnimeReviews,
+    {
+      data: animeReviews,
+      isLoading: animeReviewsLoading,
+      isFetching: animeReviewsFetching,
+      isUninitialized: animeReviewsUninitialized,
+      isError: animeReviewsError,
+    },
+  ] = useLazyGetAnimeReviewsQuery()
 
   useEffect(() => {
     AOS.init()
@@ -82,7 +96,6 @@ const FullAnime = () => {
     window.scrollTo(0, 0);
   }, []);
 
-  const anime = fullAnimeData?.data;
   const animeTitle = anime?.title_english || anime?.title || "No title";
   const animeImageUrl = anime?.images?.webp?.large_image_url || anime?.images?.webp?.image_url;
   const studios = Array.isArray(anime?.studios) ? anime.studios : [];
@@ -92,6 +105,30 @@ const FullAnime = () => {
   const reviews = Array.isArray(animeReviews?.data) ? animeReviews.data : [];
   const trailerUrl = anime?.trailer?.url;
   const trailerImageUrl = anime?.trailer?.images?.maximum_image_url;
+  const showAnimeCharactersLoader = isActiveCharacters && (
+    animeCharactersUninitialized ||
+    animeCharactersLoading ||
+    animeCharactersFetching
+  );
+  const showAnimeReviewsLoader = isActiveReviews && (
+    animeReviewsUninitialized ||
+    animeReviewsLoading ||
+    animeReviewsFetching
+  );
+  const handleShowAnimeCharacters = () => {
+    setIsActiveCharacters(true);
+
+    if (id) {
+      triggerAnimeCharacters(id, true);
+    }
+  };
+  const handleShowAnimeReviews = () => {
+    setIsActiveReviews(true);
+
+    if (id) {
+      triggerAnimeReviews(id, true);
+    }
+  };
 
   return (
     <div className="fullAnime__wrapper pb-10">
@@ -207,16 +244,16 @@ const FullAnime = () => {
             </div>
             <div className="characters mt-8">
               <h2 className="characters__title detail-section__title text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl mb-3">Characters</h2>
-              <button className={isActiveCharacters ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={() => setIsActiveCharacters(true)}>Browse character list</button>
-              {animeCharactersLoading && isActiveCharacters ? <LazyLoading message="Loading characters..." count={8} /> : animeCharactersError && isActiveCharacters ? (
+              <button className={isActiveCharacters ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowAnimeCharacters}>Browse character list</button>
+              {showAnimeCharactersLoader ? <LazyLoading message="Loading characters..." count={8} /> : animeCharactersError && isActiveCharacters ? (
                 <ErrorState
                   message="Anime characters could not be loaded."
-                  onRetry={refetchAnimeCharacters}
+                  onRetry={() => triggerAnimeCharacters(id, false)}
                   isRetrying={animeCharactersFetching}
                 />
-              ) : (
+              ) : isActiveCharacters && characters.length > 0 ? (
                 <div className="characters__content grid gap-8 sm:grid-cols-1 sm:grid-rows-1 md:grid-cols-3 md:grid-rows-2 lg:grid-cols-4 lg:grid-rows-3 xl:grid-cols-4 xl:grid-rows-3">
-                  {isActiveCharacters && characters.map(obj => {
+                  {characters.map(obj => {
                     const character = obj.character;
                     const characterName = character?.name || "Unknown";
                     const characterImageUrl = character?.images?.webp?.image_url;
@@ -237,26 +274,26 @@ const FullAnime = () => {
                     );
                   })}
                 </div>
-              )}
+              ) : isActiveCharacters ? <p>There are currently no characters for this anime.</p> : null}
             </div>
             <div className="reviews mt-5">
-              <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={() => setIsActiveReviews(true)}>Read community reviews</button>
-              {animeReviewsLoading && isActiveReviews ? <LazyLoading message="Loading reviews..." count={4} /> : animeReviewsError && isActiveReviews ? (
+              <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowAnimeReviews}>Read community reviews</button>
+              {showAnimeReviewsLoader ? <LazyLoading message="Loading reviews..." count={4} /> : animeReviewsError && isActiveReviews ? (
                 <ErrorState
                   message="Anime reviews could not be loaded."
-                  onRetry={refetchAnimeReviews}
+                  onRetry={() => triggerAnimeReviews(id, false)}
                   isRetrying={animeReviewsFetching}
                 />
-              ) : isActiveReviews && (
+              ) : isActiveReviews && reviews.length > 0 ? (
                 <>
-                  <h3 className="review__title text-3xl mb-5">{reviews.length > 0 ? <span className="text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl my-4">Review</span> : null}</h3>
+                  <h3 className="review__title text-3xl mb-5"><span className="text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl my-4">Review</span></h3>
                   <div className="reviews__content grid grid-cols-1 grid-rows-1 gap-4">
                     {reviews.map((review) => (
                       <ReviewCard key={review.mal_id} {...review} />
                     ))}
                   </div>
                 </>
-              )}
+              ) : isActiveReviews ? <p>There are currently no reviews for this anime.</p> : null}
             </div>
           </>
         ) : (

--- a/src/components/FullManga/FullManga.jsx
+++ b/src/components/FullManga/FullManga.jsx
@@ -10,7 +10,12 @@ import ErrorState from "../ErrorState/ErrorState";
 import ReviewCard from "../ReviewCard/ReviewCard";
 import AOS from "aos";
 import "aos/dist/aos.css";
-import { useGetFullMangaQuery, useGetMangaCharactersQuery, useGetMangaPicturesQuery, useGetMangaReviewsQuery } from "../../features/apiSlice";
+import {
+  useGetFullMangaQuery,
+  useGetMangaPicturesQuery,
+  useLazyGetMangaCharactersQuery,
+  useLazyGetMangaReviewsQuery,
+} from "../../features/apiSlice";
 
 const swiperBreakpoints = {
   320: {
@@ -47,27 +52,35 @@ const FullManga = () => {
     isError: fullMangaError,
     refetch: refetchFullManga,
   } = useGetFullMangaQuery(id)
+  const manga = fullMangaData?.data;
+  const canLoadMangaSecondary = Boolean(id && manga);
   const {
     data: mangaPictures,
     isLoading: mangaPicturesLoading,
     isFetching: mangaPicturesFetching,
     isError: mangaPicturesError,
     refetch: refetchMangaPictures,
-  } = useGetMangaPicturesQuery(id)
-  const {
-    data: mangaCharacters,
-    isLoading: mangaCharactersLoading,
-    isFetching: mangaCharactersFetching,
-    isError: mangaCharactersError,
-    refetch: refetchMangaCharacters,
-  } = useGetMangaCharactersQuery(id)
-  const {
-    data: mangaReviews,
-    isLoading: mangaReviewsLoading,
-    isFetching: mangaReviewsFetching,
-    isError: mangaReviewsError,
-    refetch: refetchMangaReviews,
-  } = useGetMangaReviewsQuery(id)
+  } = useGetMangaPicturesQuery(id, { skip: !canLoadMangaSecondary })
+  const [
+    triggerMangaCharacters,
+    {
+      data: mangaCharacters,
+      isLoading: mangaCharactersLoading,
+      isFetching: mangaCharactersFetching,
+      isUninitialized: mangaCharactersUninitialized,
+      isError: mangaCharactersError,
+    },
+  ] = useLazyGetMangaCharactersQuery()
+  const [
+    triggerMangaReviews,
+    {
+      data: mangaReviews,
+      isLoading: mangaReviewsLoading,
+      isFetching: mangaReviewsFetching,
+      isUninitialized: mangaReviewsUninitialized,
+      isError: mangaReviewsError,
+    },
+  ] = useLazyGetMangaReviewsQuery()
 
   useEffect(() => {
     AOS.init()
@@ -75,13 +88,36 @@ const FullManga = () => {
     window.scrollTo(0, 0);
   }, []);
 
-  const manga = fullMangaData?.data;
   const mangaTitle = manga?.title_english || manga?.title || "No title";
   const mangaImageUrl = manga?.images?.webp?.large_image_url || manga?.images?.webp?.image_url;
   const authors = Array.isArray(manga?.authors) ? manga.authors : [];
   const pictures = Array.isArray(mangaPictures?.data) ? mangaPictures.data : [];
   const characters = Array.isArray(mangaCharacters?.data) ? mangaCharacters.data : [];
   const reviews = Array.isArray(mangaReviews?.data) ? mangaReviews.data : [];
+  const showMangaCharactersLoader = isActiveCharacters && (
+    mangaCharactersUninitialized ||
+    mangaCharactersLoading ||
+    mangaCharactersFetching
+  );
+  const showMangaReviewsLoader = isActiveReviews && (
+    mangaReviewsUninitialized ||
+    mangaReviewsLoading ||
+    mangaReviewsFetching
+  );
+  const handleShowMangaCharacters = () => {
+    setIsActiveCharacters(true);
+
+    if (id) {
+      triggerMangaCharacters(id, true);
+    }
+  };
+  const handleShowMangaReviews = () => {
+    setIsActiveReviews(true);
+
+    if (id) {
+      triggerMangaReviews(id, true);
+    }
+  };
 
   return (
     <div className="fullManga__wrapper pb-10">
@@ -154,16 +190,16 @@ const FullManga = () => {
           </div>
           <div className="mangaCharacters mt-8">
             <h2 className="mangaCharacters__title detail-section__title text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl mb-3">Characters</h2>
-            <button className={isActiveCharacters ? "display-none " : 'show-btn bg-black text-white py-2 px-3'} onClick={() => setIsActiveCharacters(true)}>Browse character list</button>
-            {mangaCharactersLoading && isActiveCharacters ? <LazyLoading message="Loading manga characters..." count={8} /> : mangaCharactersError && isActiveCharacters ? (
+            <button className={isActiveCharacters ? "display-none " : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowMangaCharacters}>Browse character list</button>
+            {showMangaCharactersLoader ? <LazyLoading message="Loading manga characters..." count={8} /> : mangaCharactersError && isActiveCharacters ? (
               <ErrorState
                 message="Manga characters could not be loaded."
-                onRetry={refetchMangaCharacters}
+                onRetry={() => triggerMangaCharacters(id, false)}
                 isRetrying={mangaCharactersFetching}
               />
-            ) : (
+            ) : isActiveCharacters && characters.length > 0 ? (
               <div className="mangaCharacters__content  grid gap-8 sm:grid-cols-1 sm:grid-rows-1 md:grid-cols-3 md:grid-rows-2 lg:grid-cols-4 lg:grid-rows-3 xl:grid-cols-5 xl:grid-rows-4">
-                {isActiveCharacters && characters.map(obj => {
+                {characters.map(obj => {
                   const character = obj.character;
                   const characterName = character?.name || "Unknown";
                   const characterImageUrl = character?.images?.webp?.image_url;
@@ -179,26 +215,26 @@ const FullManga = () => {
                   );
                 })}
               </div>
-            )}
+            ) : isActiveCharacters ? <p>There are currently no characters for this manga.</p> : null}
           </div>
           <div className="reviews mt-5">
-            <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={() => setIsActiveReviews(true)}>Read community reviews</button>
-            {mangaReviewsLoading && isActiveReviews ? <LazyLoading message="Loading manga reviews..." count={4} /> : mangaReviewsError && isActiveReviews ? (
+            <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowMangaReviews}>Read community reviews</button>
+            {showMangaReviewsLoader ? <LazyLoading message="Loading manga reviews..." count={4} /> : mangaReviewsError && isActiveReviews ? (
               <ErrorState
                 message="Manga reviews could not be loaded."
-                onRetry={refetchMangaReviews}
+                onRetry={() => triggerMangaReviews(id, false)}
                 isRetrying={mangaReviewsFetching}
               />
-            ) : isActiveReviews && (
+            ) : isActiveReviews && reviews.length > 0 ? (
               <>
-                <h3 className="review__title text-3xl mb-5">{reviews.length > 0 ? <span className="text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl my-4">Review</span> : null}</h3>
+                <h3 className="review__title text-3xl mb-5"><span className="text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl my-4">Review</span></h3>
                 <div className="reviews__content grid grid-cols-1 grid-rows-1 gap-4">
                   {reviews.map((review) => (
                     <ReviewCard key={review.mal_id} {...review} />
                   ))}
                 </div>
               </>
-            )}
+            ) : isActiveReviews ? <p>There are currently no reviews for this manga.</p> : null}
           </div>
         </>
       ) : (

--- a/src/features/apiSlice.js
+++ b/src/features/apiSlice.js
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi, fetchBaseQuery, retry } from '@reduxjs/toolkit/query/react';
 
 export const buildSearchQuery = (resource, params) => {
   const searchParams = new URLSearchParams();
@@ -14,9 +14,28 @@ export const buildSearchQuery = (resource, params) => {
   return queryString ? `${resource}?${queryString}` : resource;
 };
 
+const isTransientJikanError = (error) => {
+  const status = error?.status;
+
+  return (
+    status === 429 ||
+    status === "FETCH_ERROR" ||
+    status === "TIMEOUT_ERROR" ||
+    (typeof status === "number" && status >= 500)
+  );
+};
+
+const staggeredBaseQuery = retry(
+  fetchBaseQuery({ baseUrl: 'https://api.jikan.moe/v4' }),
+  {
+    maxRetries: 2,
+    retryCondition: (error) => isTransientJikanError(error),
+  }
+);
+
 export const fetchDataApi = createApi({
   reducerPath: "fetchDataApi",
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://api.jikan.moe/v4' }),
+  baseQuery: staggeredBaseQuery,
   endpoints: (builder) => ({
     getTopAnime: builder.query({
       query: () => '/top/anime',
@@ -104,11 +123,14 @@ export const {
 
   useGetAnimeCharactersQuery,
   useGetMangaCharactersQuery,
+  useLazyGetAnimeCharactersQuery,
+  useLazyGetMangaCharactersQuery,
 
   useGetAnimeReviewsQuery,
   useGetMangaReviewsQuery,
+  useLazyGetAnimeReviewsQuery,
+  useLazyGetMangaReviewsQuery,
 
   useGetAnimeSearchQuery,
   useGetMangaSearchQuery,
 } = fetchDataApi;
-


### PR DESCRIPTION
## Summary
- Wrap Jikan requests with RTK Query retry logic for transient failures.
- Defer anime and manga character/review requests until the user opens each section.
- Keep visible detail sections gated on the main item load so secondary data does not fire too early.

## Testing
- Lint and production build passed locally.
- Full repo verification passed.
- Manual browser smoke confirmed anime and manga character/review panels load on the first click.