### PR TITLE
Update home catalog cards for denser desktop grids

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -114,6 +114,38 @@ a {
   }
 }
 
+.catalogue-grid {
+  display: grid;
+  gap: clamp(14px, 2vw, 20px);
+  grid-template-columns: minmax(0, 1fr);
+
+  > * {
+    min-width: 0;
+  }
+
+  .error-state {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width: 640px) {
+  .catalogue-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 820px) {
+  .catalogue-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1120px) {
+  .catalogue-grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
 .show-btn {
   border: 1px solid rgba(217, 164, 65, 0.45);
   border-radius: var(--radius);

--- a/src/Page/Anime.jsx
+++ b/src/Page/Anime.jsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import TopAnimeSlider from '../components/TopAnimeSlider/TopAnimeSlider'
 import LazyLoading from '../components/LazyLoading/LazyLoading';
 import ErrorState from '../components/ErrorState/ErrorState';
 import AOS from "aos";
 import "aos/dist/aos.css";
+import AnimeSearch from '../components/AnimeSearch/AnimeSearch';
 
 import RecomendationsAnime from "../components/Recomendations/RecomendationsAnime/RecomendationsAnime"
 import { useGetRecomendationAnimeQuery, useGetTopAnimeQuery } from '../features/apiSlice';
@@ -11,6 +12,9 @@ import { useGetRecomendationAnimeQuery, useGetTopAnimeQuery } from '../features/
 
 
 const Anime = () => {
+  const [orderBy, setOrderBy] = useState('score')
+  const [sortBy, setSortBy] = useState('desc')
+  const [rating, setRating] = useState('pg13')
   const {
     data: topAnime,
     isLoading: topAnimeLoading,
@@ -33,6 +37,15 @@ const Anime = () => {
 
   return (
     <>
+      <AnimeSearch
+        sortBy={sortBy}
+        setOrderBy={setOrderBy}
+        setSortBy={setSortBy}
+        setRating={setRating}
+        rating={rating}
+        orderBy={orderBy}
+        showMediaToggle={false}
+      />
       {topAnimeLoading ? (
         <LazyLoading message="Loading top anime..." count={5} />
       ) : topAnimeError ? (

--- a/src/Page/Manga.jsx
+++ b/src/Page/Manga.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import TopManga from "../components/TopManga/TopManga"
 import LazyLoading from "../components/LazyLoading/LazyLoading"
 import ErrorState from "../components/ErrorState/ErrorState"
@@ -6,8 +6,11 @@ import RecomendationsManga from "../components/Recomendations/RecomendationsMang
 import AOS from "aos";
 import "aos/dist/aos.css";
 import { useGetRecomendationMangaQuery, useGetTopMangaQuery } from "../features/apiSlice";
+import MangaSearch from "../components/MangaSearch/MangaSearch";
 
 const Manga = () => {
+  const [orderBy, setOrderBy] = useState('score')
+  const [sortBy, setSortBy] = useState('desc')
   const {
     data: topManga,
     isLoading: topMangaLoading,
@@ -30,6 +33,13 @@ const Manga = () => {
 
   return (
     <>
+      <MangaSearch
+        sortBy={sortBy}
+        orderBy={orderBy}
+        setOrderBy={setOrderBy}
+        setSortBy={setSortBy}
+        showMediaToggle={false}
+      />
       {topMangaLoading ? <LazyLoading message="Loading top manga..." count={5} /> : topMangaError ? (
         <ErrorState
           message="Top manga could not be loaded."

--- a/src/components/AnimeCard/AnimeCard.scss
+++ b/src/components/AnimeCard/AnimeCard.scss
@@ -53,25 +53,25 @@
   background: rgba(246, 240, 229, 0.93);
   border-radius: 999px;
   color: #181613;
-  font-size: 0.92rem;
+  font-size: 0.82rem;
   font-weight: 900;
   position: absolute;
-  right: 12px;
-  top: 12px;
+  right: 10px;
+  top: 10px;
   z-index: 1;
-  padding: 6px 11px;
+  padding: 5px 9px;
 }
 
 .card__textWrapper {
   display: grid;
   flex: 1;
-  gap: 11px;
-  padding: 16px;
+  gap: 9px;
+  padding: 13px;
 }
 
 .card__eyebrow {
   color: var(--accent);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   font-weight: 900;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -79,9 +79,9 @@
 
 .card__title {
   color: var(--text-primary);
-  font-size: 1.04rem;
+  font-size: 0.96rem;
   font-weight: 850;
-  line-height: 1.35;
+  line-height: 1.32;
 }
 
 .card__meta,
@@ -92,7 +92,7 @@
 
   span {
     color: var(--text-subtle);
-    font-size: 0.76rem;
+    font-size: 0.7rem;
     font-weight: 800;
     letter-spacing: 0.06em;
     text-transform: uppercase;
@@ -100,7 +100,7 @@
 
   strong {
     color: var(--text-muted);
-    font-size: 0.94rem;
+    font-size: 0.84rem;
     font-weight: 650;
     line-height: 1.35;
   }
@@ -116,7 +116,7 @@
     border: 1px solid rgba(240, 220, 184, 0.1);
     border-radius: 999px;
     color: var(--text-primary);
-    font-size: 0.78rem;
-    padding: 5px 8px;
+    font-size: 0.72rem;
+    padding: 4px 7px;
   }
 }

--- a/src/components/AnimeSearch/AnimeSearch.jsx
+++ b/src/components/AnimeSearch/AnimeSearch.jsx
@@ -59,7 +59,7 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
           <Sort setSortBy={setSortBy} />
         </div>
       </div>
-      <div className="search-content grid gap-4 sm:grid-cols-1 md:grid-cols-2 md:grid-rows-1 lg:grid-cols-3 lg:grid-rows-2 xl:grid-cols-3 xl:grid-rows-2">
+      <div className="search-content catalogue-grid">
         {isLoading ? (
           <LazyLoading message="Loading anime matches..." count={6} />
         ) : isError ? (

--- a/src/components/AnimeSearch/AnimeSearch.jsx
+++ b/src/components/AnimeSearch/AnimeSearch.jsx
@@ -11,7 +11,7 @@ import AnimeCard from "../AnimeCard/AnimeCard.jsx";
 import "./animeSearch.scss";
 import useDebounce from "../../hooks/useDebounce";
 
-const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy }) => {
+const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy, showMediaToggle = true }) => {
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebounce(query, 500);
   const {
@@ -34,10 +34,12 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
           <p className="search-panel__subtitle">A cleaner shelf for top-rated series, films, and comfort rewatches. Search first, then tune the list by rating and mood.</p>
         </div>
         <div className="search-panel__actions">
-          <div className="media-toggle" aria-label="Choose catalogue type">
-            <span className="media-toggle__item media-toggle__item--active">Anime</span>
-            <a className="media-toggle__item" href="#manga">Manga</a>
-          </div>
+          {showMediaToggle ? (
+            <div className="media-toggle" aria-label="Choose catalogue type">
+              <span className="media-toggle__item media-toggle__item--active">Anime</span>
+              <a className="media-toggle__item" href="#manga">Manga</a>
+            </div>
+          ) : null}
           <input className="searchInput" placeholder="Search anime..." type="text" value={query} onChange={event => setQuery(event.target.value)} />
         </div>
       </div>
@@ -70,7 +72,7 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
           />
         ) : (
           animeSearchItems.map(obj => (
-            <Link key={obj.mal_id} to={`anime/${obj.mal_id}`}>
+            <Link key={obj.mal_id} to={`/anime/${obj.mal_id}`}>
               <AnimeCard {...obj} />
             </Link>
           ))
@@ -87,6 +89,7 @@ AnimeSearch.propTypes = {
   orderBy: PropTypes.string.isRequired,
   rating: PropTypes.string.isRequired,
   sortBy: PropTypes.string.isRequired,
+  showMediaToggle: PropTypes.bool,
 };
 
 export default AnimeSearch;

--- a/src/components/MangaCard/mangaCard.scss
+++ b/src/components/MangaCard/mangaCard.scss
@@ -53,11 +53,11 @@
   background: rgba(246, 240, 229, 0.93);
   border-radius: 999px;
   color: #181613;
-  font-size: 0.92rem;
+  font-size: 0.82rem;
   font-weight: 900;
   position: absolute;
-  right: 12px;
-  top: 12px;
+  right: 10px;
+  top: 10px;
   z-index: 1;
-  padding: 6px 11px;
+  padding: 5px 9px;
 }

--- a/src/components/MangaSearch/MangaSearch.jsx
+++ b/src/components/MangaSearch/MangaSearch.jsx
@@ -10,7 +10,7 @@ import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
 import "./mangaSearch.scss";
 
-const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy }) => {
+const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy, showMediaToggle = true }) => {
   const [queryManga, setQueryManga] = useState("");
   const debouncedQuery = useDebounce(queryManga, 500);
 
@@ -32,10 +32,12 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy }) => {
           <p className="search-panel__subtitle">Move from popular series to quieter finds with the same simple search and sort rhythm.</p>
         </div>
         <div className="search-panel__actions">
-          <div className="media-toggle" aria-label="Choose catalogue type">
-            <a className="media-toggle__item" href="#anime">Anime</a>
-            <span className="media-toggle__item media-toggle__item--active">Manga</span>
-          </div>
+          {showMediaToggle ? (
+            <div className="media-toggle" aria-label="Choose catalogue type">
+              <a className="media-toggle__item" href="#anime">Anime</a>
+              <span className="media-toggle__item media-toggle__item--active">Manga</span>
+            </div>
+          ) : null}
           <input className="searchInput" placeholder="Search manga..." type="text" value={queryManga} onChange={event => setQueryManga(event.target.value)} />
         </div>
       </div>
@@ -64,7 +66,7 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy }) => {
           />
         ) : (
           mangaSearchItems.map(obj => (
-            <Link key={obj.mal_id} to={`manga/${obj.mal_id}`}>
+            <Link key={obj.mal_id} to={`/manga/${obj.mal_id}`}>
               <MangaCard {...obj} />
             </Link>
           ))
@@ -79,6 +81,7 @@ MangaSearch.propTypes = {
   setOrderBy: PropTypes.func.isRequired,
   setSortBy: PropTypes.func.isRequired,
   sortBy: PropTypes.string.isRequired,
+  showMediaToggle: PropTypes.bool,
 };
 
 export default MangaSearch;

--- a/src/components/MangaSearch/MangaSearch.jsx
+++ b/src/components/MangaSearch/MangaSearch.jsx
@@ -53,7 +53,7 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy }) => {
           <Sort setSortBy={setSortBy} />
         </div>
       </div>
-      <div className="search-content grid gap-4 sm:grid-cols-1 md:grid-cols-2 md:grid-rows-1 lg:grid-cols-3 lg:grid-rows-2 xl:grid-cols-4 xl:grid-rows-3">
+      <div className="search-content catalogue-grid">
         {isLoading ? (
           <LazyLoading message="Loading manga matches..." count={8} />
         ) : isError ? (


### PR DESCRIPTION
## Summary
- Replace the hardcoded anime and manga search grids with a shared responsive `catalogue-grid`.
- Tighten card spacing and typography so more posters fit per row without losing readability.
- Preserve the existing poster-led look, hover treatment, links, search flow, and loading/error states.

## Testing
- `npm run verify` passed.
- Browser-checked the home page at the desktop viewport and confirmed the catalog now renders 5 cards per row with intact poster cropping and spacing.
- Verified the responsive breakpoints in CSS keep the layout stacked on smaller screens.