### PR TITLE
Add runtime Jikan caching and PWA update prompt

### DIFF
--- a/docs/quality/index.md
+++ b/docs/quality/index.md
@@ -3,12 +3,16 @@
 ## Required Local Checks
 
 - `npm run harness:check`
+- `npm run pwa:check`
 - `npm run lint`
 - `npm run build`
+- `npm run pwa:dist-check`
+- `npm run pwa:e2e`
 - `npm run verify`
 
 `npm run verify` is the preferred final gate for broad edits because it runs the
-harness docs check, lint, and production build.
+harness docs check, PWA checks, lint, production build, and the PWA browser
+smoke test.
 
 ## Security Check
 
@@ -38,10 +42,31 @@ Check these flows in a browser:
 - Manga detail page tolerates missing nested fields.
 - Refreshing a nested route still loads through the Netlify SPA fallback after
   deployment.
+- After opening Anime and Manga online, switch the browser offline and confirm
+  those views still show previously cached Jikan-backed content.
+- Trigger or wait for a changed service worker and confirm the app shows a
+  visible "New version" update notice with an Update action.
+
+## Netlify PWA Checks
+
+On a real Netlify deploy-preview, run Chrome Lighthouse against the deployed URL
+and confirm the PWA/installability audit does not flag missing manifest, service
+worker, icon, or offline fallback requirements.
+
+Also manually check this deploy-preview flow:
+
+1. Open the home page, `/anime`, and `/manga` while online.
+2. Use DevTools to switch the page offline.
+3. Reload `/anime` and `/manga`; the app shell should load and previously opened
+   Jikan data should still render from cache.
+4. Deploy a changed build and confirm the update notice appears before applying
+   the new service worker.
 
 ## Known Risks
 
 - Jikan may return rate limits, partial data, or null nested fields.
+- Jikan runtime cache can serve data up to 7 days old while offline.
 - Some legacy component names use `Recomendations`; do not rename broadly unless
   a plan explicitly covers the migration.
-- The app has no automated UI tests yet, so manual smoke checks still matter.
+- The PWA browser smoke is intentionally narrow, so manual smoke checks still
+  matter for full release confidence.

--- a/e2e/pwa.spec.js
+++ b/e2e/pwa.spec.js
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+
+const jikanFixtures = {
+  'https://api.jikan.moe/v4/top/anime': {
+    data: [
+      {
+        mal_id: 1,
+        title: 'Cached Anime',
+        score: 9.7,
+        episodes: 12,
+        status: 'Finished Airing',
+        images: { webp: {} },
+      },
+    ],
+  },
+  'https://api.jikan.moe/v4/top/manga': {
+    data: [
+      {
+        mal_id: 2,
+        title: 'Cached Manga',
+        score: 9.5,
+        chapters: 42,
+        images: { webp: {} },
+      },
+    ],
+  },
+  'https://api.jikan.moe/v4/recommendations/anime': {
+    data: [
+      {
+        entry: [
+          {
+            mal_id: 3,
+            title: 'Cached Anime Match',
+            images: { webp: {} },
+          },
+        ],
+      },
+    ],
+  },
+  'https://api.jikan.moe/v4/recommendations/manga': {
+    data: [
+      {
+        entry: [
+          {
+            mal_id: 4,
+            title: 'Cached Manga Match',
+            images: { webp: {} },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const activateServiceWorker = async (page) => {
+  await page.waitForFunction(async () => {
+    if (!('serviceWorker' in navigator)) {
+      return false;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+    return Boolean(registration.active);
+  });
+
+  const hasController = await page.evaluate(() => Boolean(navigator.serviceWorker.controller));
+
+  if (!hasController) {
+    await page.reload({ waitUntil: 'networkidle' });
+  }
+
+  await page.waitForFunction(() => Boolean(navigator.serviceWorker.controller));
+};
+
+const seedJikanCache = async (page) => {
+  const cachedEntryCount = await page.evaluate(async (fixtures) => {
+    const cache = await caches.open('jikan-api-cache');
+
+    await Promise.all(
+      Object.entries(fixtures).map(([url, body]) =>
+        cache.put(
+          url,
+          new Response(JSON.stringify(body), {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          })
+        )
+      )
+    );
+
+    const keys = await cache.keys();
+
+    return keys.length;
+  }, jikanFixtures);
+
+  expect(cachedEntryCount).toBeGreaterThanOrEqual(Object.keys(jikanFixtures).length);
+};
+
+test('PWA serves the app shell and cached Jikan data offline', async ({ page, context }) => {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'AnimeBounty-Info' })).toBeVisible();
+
+  await activateServiceWorker(page);
+  await seedJikanCache(page);
+
+  await context.setOffline(true);
+
+  try {
+    await page.goto('/anime', { waitUntil: 'networkidle' });
+    await expect(page.getByText('Offline mode')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Top Anime' })).toBeVisible();
+    await expect(page.locator('.slide__text').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Recommended anime' })).toBeVisible();
+    await expect(page.locator('.rec__card-content').first()).toBeVisible();
+    await expect(page.getByText(/anime .* could not be loaded/i)).toHaveCount(0);
+
+    await page.goto('/manga', { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Top Manga' })).toBeVisible();
+    await expect(page.locator('.slide__text').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Recommended manga' })).toBeVisible();
+    await expect(page.locator('.rec__card-content').first()).toBeVisible();
+    await expect(page.getByText(/manga .* could not be loaded/i)).toHaveCount(0);
+
+    await page.goto('/anime/1', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('button', { name: 'AnimeBounty-Info' })).toBeVisible();
+  } finally {
+    await context.setOffline(false);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "swiper": "^12.1.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
         "@vitejs/plugin-react": "^5.2.0",
@@ -2624,6 +2625,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -5984,6 +6001,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "harness:check": "node scripts/verify-harness-docs.mjs",
     "pwa:check": "node scripts/verify-pwa.mjs",
     "pwa:dist-check": "node scripts/verify-pwa-dist.mjs",
+    "pwa:e2e": "playwright test",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "verify": "npm run harness:check && npm run pwa:check && npm run lint && npm run build && npm run pwa:dist-check"
+    "verify": "npm run harness:check && npm run pwa:check && npm run lint && npm run build && npm run pwa:dist-check && npm run pwa:e2e"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.11.2",
@@ -25,6 +26,7 @@
     "swiper": "^12.1.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^5.2.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1 --port 4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: 'http://127.0.0.1:4173',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/scripts/verify-pwa-dist.mjs
+++ b/scripts/verify-pwa-dist.mjs
@@ -4,10 +4,12 @@ import { join } from 'node:path';
 const root = process.cwd();
 const failures = [];
 const distFiles = existsSync(join(root, 'dist')) ? readdirSync(join(root, 'dist')) : [];
+const distAssetFiles = existsSync(join(root, 'dist/assets'))
+  ? readdirSync(join(root, 'dist/assets'))
+  : [];
 
 const requiredDistFiles = [
   'dist/manifest.webmanifest',
-  'dist/registerSW.js',
   'dist/sw.js',
   'dist/apple-touch-icon.png',
   'dist/pwa-192x192.png',
@@ -31,7 +33,6 @@ if (existsSync(join(root, 'dist/index.html'))) {
 
   [
     '<link rel="manifest" href="/manifest.webmanifest">',
-    'id="vite-plugin-pwa:register-sw"',
     'rel="apple-touch-icon"',
   ].forEach((needle) => {
     if (!indexHtml.includes(needle)) {
@@ -55,6 +56,42 @@ if (existsSync(join(root, 'dist/manifest.webmanifest'))) {
     failures.push('manifest does not include a maskable icon');
   }
 }
+
+if (existsSync(join(root, 'dist/sw.js'))) {
+  const sw = readFileSync(join(root, 'dist/sw.js'), 'utf8');
+
+  const swChecks = [
+    ['jikan-api-cache', /jikan-api-cache/],
+    ['NetworkFirst', /NetworkFirst/],
+    ['api.jikan.moe route', /api\\\.jikan\\\.moe/],
+    ['ExpirationPlugin', /ExpirationPlugin/],
+    ['CacheableResponsePlugin', /CacheableResponsePlugin/],
+    ['maxEntries 80', /maxEntries:80/],
+    ['maxAgeSeconds 7 days', /maxAgeSeconds:604800/],
+    ['networkTimeoutSeconds 5', /networkTimeoutSeconds:5/],
+  ];
+
+  swChecks.forEach(([label, pattern]) => {
+    if (!pattern.test(sw)) {
+      failures.push(`dist/sw.js does not include ${label}`);
+    }
+  });
+}
+
+const distJs = distAssetFiles
+  .filter((file) => file.endsWith('.js'))
+  .map((file) => readFileSync(join(root, 'dist/assets', file), 'utf8'))
+  .join('\n');
+
+[
+  'A new version is available.',
+  'Offline ready',
+  'Previously opened anime and manga data can now be shown offline.',
+].forEach((needle) => {
+  if (!distJs.includes(needle)) {
+    failures.push(`dist assets do not include ${needle}`);
+  }
+});
 
 if (failures.length > 0) {
   console.error('PWA dist verification failed:');

--- a/scripts/verify-pwa.mjs
+++ b/scripts/verify-pwa.mjs
@@ -22,15 +22,59 @@ requiredFiles.forEach((file) => {
 const viteConfig = readFileSync(join(root, 'vite.config.js'), 'utf8');
 const indexHtml = readFileSync(join(root, 'index.html'), 'utf8');
 const mainLayout = readFileSync(join(root, 'src/layouts/MainLayout.jsx'), 'utf8');
+const serviceWorkerNotice = readFileSync(
+  join(root, 'src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx'),
+  'utf8'
+);
+const offlineNotice = readFileSync(
+  join(root, 'src/components/OfflineNotice/OfflineNotice.jsx'),
+  'utf8'
+);
 
 [
   ['vite.config.js', viteConfig, 'VitePWA'],
   ['vite.config.js', viteConfig, 'registerType'],
+  ['vite.config.js', viteConfig, "registerType: 'prompt'"],
   ['vite.config.js', viteConfig, 'cleanupOutdatedCaches'],
   ['vite.config.js', viteConfig, 'navigateFallback'],
+  ['vite.config.js', viteConfig, 'runtimeCaching'],
+  ['vite.config.js', viteConfig, 'api\\.jikan\\.moe'],
+  ['vite.config.js', viteConfig, "handler: 'NetworkFirst'"],
+  ['vite.config.js', viteConfig, "method: 'GET'"],
+  ['vite.config.js', viteConfig, "cacheName: 'jikan-api-cache'"],
+  ['vite.config.js', viteConfig, 'maxEntries: 80'],
+  ['vite.config.js', viteConfig, 'maxAgeSeconds: 60 * 60 * 24 * 7'],
+  ['vite.config.js', viteConfig, 'networkTimeoutSeconds: 5'],
+  ['vite.config.js', viteConfig, 'statuses: [200]'],
   ['index.html', indexHtml, 'apple-mobile-web-app-capable'],
   ['index.html', indexHtml, 'apple-touch-icon'],
   ['src/layouts/MainLayout.jsx', mainLayout, 'OfflineNotice'],
+  ['src/layouts/MainLayout.jsx', mainLayout, 'ServiceWorkerUpdateNotice'],
+  [
+    'src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx',
+    serviceWorkerNotice,
+    "from 'virtual:pwa-register/react'",
+  ],
+  [
+    'src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx',
+    serviceWorkerNotice,
+    'needRefresh',
+  ],
+  [
+    'src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx',
+    serviceWorkerNotice,
+    'offlineReady',
+  ],
+  [
+    'src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx',
+    serviceWorkerNotice,
+    'updateServiceWorker(true)',
+  ],
+  [
+    'src/components/OfflineNotice/OfflineNotice.jsx',
+    offlineNotice,
+    'previously opened anime or manga data',
+  ],
 ].forEach(([file, contents, needle]) => {
   if (!contents.includes(needle)) {
     failures.push(`${file} does not include ${needle}`);

--- a/src/components/OfflineNotice/OfflineNotice.jsx
+++ b/src/components/OfflineNotice/OfflineNotice.jsx
@@ -12,7 +12,7 @@ const OfflineNotice = () => {
     <div className="offline-notice" role="status" aria-live="polite">
       <span className="offline-notice__label">Offline mode</span>
       <span className="offline-notice__message">
-        Saved app screens can still open. Live Jikan data needs a connection.
+        Saved app screens and previously opened anime or manga data can still appear.
       </span>
     </div>
   );

--- a/src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx
+++ b/src/components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice.jsx
@@ -1,0 +1,64 @@
+import { useRegisterSW } from 'virtual:pwa-register/react';
+import './serviceWorkerUpdateNotice.scss';
+
+const updateCheckIntervalMs = 60 * 60 * 1000;
+
+const ServiceWorkerUpdateNotice = () => {
+  const {
+    offlineReady: [offlineReady, setOfflineReady],
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) {
+        return;
+      }
+
+      setInterval(() => {
+        registration.update();
+      }, updateCheckIntervalMs);
+    },
+  });
+
+  if (!offlineReady && !needRefresh) {
+    return null;
+  }
+
+  const closeNotice = () => {
+    setOfflineReady(false);
+    setNeedRefresh(false);
+  };
+
+  return (
+    <div className="service-worker-notice" role="status" aria-live="polite">
+      <span className="service-worker-notice__label">
+        {needRefresh ? 'New version' : 'Offline ready'}
+      </span>
+      <span className="service-worker-notice__message">
+        {needRefresh
+          ? 'A new version is available.'
+          : 'Previously opened anime and manga data can now be shown offline.'}
+      </span>
+      <div className="service-worker-notice__actions">
+        {needRefresh ? (
+          <button
+            className="service-worker-notice__button service-worker-notice__button--primary"
+            type="button"
+            onClick={() => updateServiceWorker(true)}
+          >
+            Update
+          </button>
+        ) : null}
+        <button
+          className="service-worker-notice__button"
+          type="button"
+          onClick={closeNotice}
+        >
+          {needRefresh ? 'Later' : 'Got it'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceWorkerUpdateNotice;

--- a/src/components/ServiceWorkerUpdateNotice/serviceWorkerUpdateNotice.scss
+++ b/src/components/ServiceWorkerUpdateNotice/serviceWorkerUpdateNotice.scss
@@ -1,0 +1,63 @@
+.service-worker-notice {
+  align-items: center;
+  background: rgba(22, 24, 20, 0.96);
+  border-bottom: 1px solid rgba(143, 189, 120, 0.34);
+  color: var(--text-muted);
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px clamp(16px, 3vw, 28px);
+  text-align: center;
+}
+
+.service-worker-notice__label {
+  color: #8fbd78;
+  flex: 0 0 auto;
+  font-size: 0.76rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.service-worker-notice__message {
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.service-worker-notice__actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.service-worker-notice__button {
+  border: 1px solid rgba(240, 220, 184, 0.22);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 800;
+  min-height: 34px;
+  padding: 6px 12px;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.service-worker-notice__button:hover,
+.service-worker-notice__button:focus-visible {
+  background: rgba(240, 220, 184, 0.08);
+  border-color: rgba(240, 220, 184, 0.36);
+}
+
+.service-worker-notice__button--primary {
+  background: rgba(143, 189, 120, 0.16);
+  border-color: rgba(143, 189, 120, 0.42);
+  color: var(--text-primary);
+}
+
+@media (max-width: 640px) {
+  .service-worker-notice {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+    text-align: left;
+  }
+}

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,12 +1,14 @@
 import { Outlet } from "react-router-dom"
 import Header from "../components/Header/Header"
 import OfflineNotice from "../components/OfflineNotice/OfflineNotice"
+import ServiceWorkerUpdateNotice from "../components/ServiceWorkerUpdateNotice/ServiceWorkerUpdateNotice"
 import './layout.scss'
 
 const MainLayout = () => {
   return (
     <div className='Wrapper'>
       <Header />
+      <ServiceWorkerUpdateNotice />
       <OfflineNotice />
       <div className="container">
         <Outlet />

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       injectRegister: 'auto',
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {
@@ -43,6 +43,24 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
         navigateFallback: '/index.html',
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/api\.jikan\.moe\/v4\/.*$/i,
+            handler: 'NetworkFirst',
+            method: 'GET',
+            options: {
+              cacheName: 'jikan-api-cache',
+              expiration: {
+                maxEntries: 80,
+                maxAgeSeconds: 60 * 60 * 24 * 7,
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+              networkTimeoutSeconds: 5,
+            },
+          },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- Add Workbox `NetworkFirst` caching for Jikan GET requests so previously loaded anime/manga data remains available offline.
- Replace auto-update handling with a small in-app update notice and keep the existing offline banner aligned with cached-content behavior.
- Extend PWA verification plus add a Playwright smoke test for offline and app-shell flows on production preview.

## Testing
- `npm run verify`
- `npm audit --audit-level=high`