### PR TITLE
Add Jikan genre and detail endpoint UI

### DIFF
--- a/e2e/jikan-endpoints.spec.js
+++ b/e2e/jikan-endpoints.spec.js
@@ -1,0 +1,225 @@
+import { expect, test } from '@playwright/test';
+
+const animeItem = (malId, title) => ({
+  mal_id: malId,
+  title,
+  score: 8.4,
+  episodes: 12,
+  aired: { string: 'Apr 2026' },
+  images: { webp: {} },
+  genres: [{ mal_id: 2, name: 'Adventure' }],
+});
+
+const mangaItem = (malId, title) => ({
+  mal_id: malId,
+  title,
+  score: 8.1,
+  chapters: 48,
+  images: { webp: {} },
+  genres: [{ mal_id: 8, name: 'Drama' }],
+});
+
+const routeJikan = async (page) => {
+  await page.route('https://api.jikan.moe/v4/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const { pathname, searchParams } = requestUrl;
+    let body = { data: [] };
+
+    if (pathname === '/v4/top/anime') {
+      body = { data: [animeItem(10, 'Top Anime Fixture')] };
+    } else if (pathname === '/v4/recommendations/anime') {
+      body = { data: [{ entry: [animeItem(11, 'Recommended Anime Fixture')] }] };
+    } else if (pathname === '/v4/anime') {
+      body = {
+        data: [
+          animeItem(
+            searchParams.get('genres') === '2' ? 12 : 13,
+            searchParams.get('genres') === '2' ? 'Adventure Anime Pick' : 'Search Anime Fixture'
+          ),
+        ],
+      };
+    } else if (pathname === '/v4/seasons/now') {
+      body = { data: [animeItem(14, 'Season Now Pick')] };
+    } else if (pathname === '/v4/seasons/upcoming') {
+      body = { data: [animeItem(15, 'Upcoming Season Pick')] };
+    } else if (pathname === '/v4/schedules') {
+      body = { data: [animeItem(16, 'Monday Schedule Pick')] };
+    } else if (pathname === '/v4/genres/anime') {
+      body = { data: [{ mal_id: 2, name: 'Adventure', count: 200 }] };
+    } else if (pathname === '/v4/top/manga') {
+      body = { data: [mangaItem(20, 'Top Manga Fixture')] };
+    } else if (pathname === '/v4/recommendations/manga') {
+      body = { data: [{ entry: [mangaItem(21, 'Recommended Manga Fixture')] }] };
+    } else if (pathname === '/v4/manga') {
+      body = {
+        data: [
+          mangaItem(
+            searchParams.get('genres') === '8' ? 22 : 23,
+            searchParams.get('genres') === '8' ? 'Drama Manga Pick' : 'Search Manga Fixture'
+          ),
+        ],
+      };
+    } else if (pathname === '/v4/genres/manga') {
+      body = { data: [{ mal_id: 8, name: 'Drama', count: 180 }] };
+    } else if (pathname === '/v4/anime/1') {
+      body = {
+        data: {
+          ...animeItem(1, 'Detail Anime Fixture'),
+          title_english: 'Detail Anime Fixture',
+          status: 'Finished Airing',
+          year: 2026,
+          rating: 'PG-13',
+          studios: [{ mal_id: 1, name: 'Studio Fixture' }],
+          trailer: { url: null, images: {} },
+        },
+      };
+    } else if (pathname === '/v4/anime/1/pictures' || pathname === '/v4/anime/1/episodes') {
+      body = { data: [] };
+    } else if (pathname === '/v4/anime/1/characters') {
+      body = {
+        data: [
+          {
+            role: 'Main',
+            character: {
+              mal_id: 777,
+              name: 'Profile Character',
+              images: { webp: {} },
+            },
+            voice_actors: [],
+          },
+        ],
+      };
+    } else if (pathname === '/v4/anime/1/relations') {
+      body = {
+        data: [
+          {
+            relation: 'Sequel',
+            entry: [{ mal_id: 9, type: 'anime', name: 'Relation Anime Fixture', url: 'https://myanimelist.net/anime/9' }],
+          },
+        ],
+      };
+    } else if (pathname === '/v4/anime/1/streaming') {
+      body = { data: [{ name: 'Crunchyroll Fixture', url: 'https://example.com/stream' }] };
+    } else if (pathname === '/v4/anime/1/videos') {
+      body = {
+        data: {
+          promo: [
+            {
+              title: 'Promo Fixture',
+              trailer: {
+                url: 'https://example.com/video',
+                images: { image_url: null },
+              },
+            },
+          ],
+        },
+      };
+    } else if (pathname === '/v4/manga/2') {
+      body = {
+        data: {
+          ...mangaItem(2, 'Detail Manga Fixture'),
+          title_english: 'Detail Manga Fixture',
+          status: 'Publishing',
+          published: { string: '2026' },
+          authors: [{ mal_id: 1, name: 'Author Fixture' }],
+        },
+      };
+    } else if (pathname === '/v4/manga/2/pictures') {
+      body = { data: [] };
+    } else if (pathname === '/v4/manga/2/characters') {
+      body = {
+        data: [
+          {
+            role: 'Main',
+            character: {
+              mal_id: 777,
+              name: 'Profile Character',
+              images: { webp: {} },
+            },
+          },
+        ],
+      };
+    } else if (pathname === '/v4/manga/2/relations') {
+      body = {
+        data: [
+          {
+            relation: 'Adaptation',
+            entry: [{ mal_id: 1, type: 'anime', name: 'Manga Relation Anime', url: 'https://myanimelist.net/anime/1' }],
+          },
+        ],
+      };
+    } else if (pathname === '/v4/characters/777') {
+      body = {
+        data: {
+          mal_id: 777,
+          name: 'Profile Character',
+          name_kanji: 'プロフィール',
+          favorites: 1234,
+          about: 'A short mocked character biography.',
+          images: { webp: {} },
+        },
+      };
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+};
+
+test.beforeEach(async ({ page }) => {
+  await routeJikan(page);
+});
+
+test('anime page lazy-loads seasonal spotlight and filters search by genre', async ({ page }) => {
+  await page.goto('/anime');
+
+  await expect(page.getByRole('heading', { name: 'Seasonal spotlight' })).toBeVisible();
+  await expect(page.getByText('Season Now Pick')).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Open seasonal spotlight' }).click();
+  await expect(page.getByText('Season Now Pick')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Schedule' }).click();
+  await expect(page.getByText('Monday Schedule Pick')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Adventure' }).click();
+  await expect(page.getByText('Adventure Anime Pick')).toBeVisible();
+});
+
+test('manga page filters search by manga genre', async ({ page }) => {
+  await page.goto('/manga');
+
+  await page.getByRole('button', { name: 'Drama' }).click();
+  await expect(page.getByText('Drama Manga Pick')).toBeVisible();
+});
+
+test('anime details expose relations, streaming, videos, and character profile on demand', async ({ page }) => {
+  await page.goto('/anime/1');
+
+  await page.getByRole('button', { name: 'Explore relations' }).click();
+  await expect(page.getByText('Relation Anime Fixture')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Find streams' }).click();
+  await expect(page.getByRole('link', { name: 'Crunchyroll Fixture' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Watch videos' }).click();
+  await expect(page.getByRole('link', { name: 'Promo Fixture' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Browse character list' }).click();
+  await page.getByRole('button', { name: 'Open profile for Profile Character' }).click();
+  await expect(page.getByRole('heading', { name: 'Profile Character' })).toBeVisible();
+  await expect(page.getByText('A short mocked character biography.')).toBeVisible();
+});
+
+test('manga details expose relations and character profile on demand', async ({ page }) => {
+  await page.goto('/manga/2');
+
+  await page.getByRole('button', { name: 'Explore relations' }).click();
+  await expect(page.getByText('Manga Relation Anime')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Browse character list' }).click();
+  await page.getByRole('button', { name: 'Open profile for Profile Character' }).click();
+  await expect(page.getByRole('heading', { name: 'Profile Character' })).toBeVisible();
+});

--- a/e2e/pwa.spec.js
+++ b/e2e/pwa.spec.js
@@ -13,6 +13,20 @@ const jikanFixtures = {
       },
     ],
   },
+  'https://api.jikan.moe/v4/anime?order_by=score&rating=pg13&sort=desc': {
+    data: [
+      {
+        mal_id: 5,
+        title: 'Cached Anime Search',
+        score: 9.1,
+        episodes: 24,
+        images: { webp: {} },
+      },
+    ],
+  },
+  'https://api.jikan.moe/v4/genres/anime': {
+    data: [{ mal_id: 2, name: 'Adventure' }],
+  },
   'https://api.jikan.moe/v4/top/manga': {
     data: [
       {
@@ -23,6 +37,20 @@ const jikanFixtures = {
         images: { webp: {} },
       },
     ],
+  },
+  'https://api.jikan.moe/v4/manga?order_by=score&sort=desc': {
+    data: [
+      {
+        mal_id: 6,
+        title: 'Cached Manga Search',
+        score: 8.9,
+        chapters: 51,
+        images: { webp: {} },
+      },
+    ],
+  },
+  'https://api.jikan.moe/v4/genres/manga': {
+    data: [{ mal_id: 8, name: 'Drama' }],
   },
   'https://api.jikan.moe/v4/recommendations/anime': {
     data: [

--- a/src/Page/Anime.jsx
+++ b/src/Page/Anime.jsx
@@ -5,6 +5,7 @@ import ErrorState from '../components/ErrorState/ErrorState';
 import AOS from "aos";
 import "aos/dist/aos.css";
 import AnimeSearch from '../components/AnimeSearch/AnimeSearch';
+import SeasonalSpotlight from '../components/SeasonalSpotlight/SeasonalSpotlight';
 
 import RecomendationsAnime from "../components/Recomendations/RecomendationsAnime/RecomendationsAnime"
 import { useGetRecomendationAnimeQuery, useGetTopAnimeQuery } from '../features/apiSlice';
@@ -46,6 +47,7 @@ const Anime = () => {
         orderBy={orderBy}
         showMediaToggle={false}
       />
+      <SeasonalSpotlight />
       {topAnimeLoading ? (
         <LazyLoading message="Loading top anime..." count={5} />
       ) : topAnimeError ? (

--- a/src/components/AnimeSearch/AnimeSearch.jsx
+++ b/src/components/AnimeSearch/AnimeSearch.jsx
@@ -1,18 +1,20 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
-import { useGetAnimeSearchQuery } from "../../features/apiSlice";
+import { useGetAnimeGenresQuery, useGetAnimeSearchQuery } from "../../features/apiSlice";
 import Filter from "../Filter/Filter";
 import Rating from "../Filter/Rating";
 import Sort from "../Filter/Sort";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
 import AnimeCard from "../AnimeCard/AnimeCard.jsx";
+import GenreChips from "../GenreChips/GenreChips";
 import "./animeSearch.scss";
 import useDebounce from "../../hooks/useDebounce";
 
 const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy, showMediaToggle = true }) => {
   const [query, setQuery] = useState("");
+  const [selectedGenreId, setSelectedGenreId] = useState(null);
   const debouncedQuery = useDebounce(query, 500);
   const {
     data: animeSearch,
@@ -20,7 +22,13 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
     isFetching,
     isError,
     refetch,
-  } = useGetAnimeSearchQuery({ orderBy, rating, sortBy, query: debouncedQuery });
+  } = useGetAnimeSearchQuery({ orderBy, rating, sortBy, query: debouncedQuery, genreId: selectedGenreId });
+  const {
+    data: animeGenres,
+    isFetching: animeGenresFetching,
+    isError: animeGenresError,
+    refetch: refetchAnimeGenres,
+  } = useGetAnimeGenresQuery();
   const animeSearchItems = animeSearch?.data ?? [];
 
 
@@ -46,7 +54,7 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
       <div className="filter search-filters">
         <div className="search-filters__summary">
           <span>Current shelf</span>
-          <strong>{orderBy} / {rating} / {sortBy}</strong>
+          <strong>{orderBy} / {rating} / {sortBy}{selectedGenreId ? " / genre" : ""}</strong>
         </div>
         <div className="search-filters__group">
           <p>Order by</p>
@@ -61,6 +69,15 @@ const AnimeSearch = ({ setOrderBy, setRating, setSortBy, orderBy, rating, sortBy
           <Sort setSortBy={setSortBy} />
         </div>
       </div>
+      <GenreChips
+        title="Anime"
+        genres={animeGenres?.data ?? []}
+        isError={animeGenresError}
+        isFetching={animeGenresFetching}
+        onRetry={refetchAnimeGenres}
+        selectedGenreId={selectedGenreId}
+        onSelectGenre={setSelectedGenreId}
+      />
       <div className="search-content catalogue-grid">
         {isLoading ? (
           <LazyLoading message="Loading anime matches..." count={6} />

--- a/src/components/FullAnime/FullAnime.jsx
+++ b/src/components/FullAnime/FullAnime.jsx
@@ -7,6 +7,12 @@ import "swiper/css/autoplay";
 import ReviewCard from "../ReviewCard/ReviewCard";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
+import {
+  CharacterProfilePanel,
+  RelationsPanel,
+  StreamingPanel,
+  VideosPanel,
+} from "../JikanDetailExtras/JikanDetailExtras";
 import playButton from "../../assets/images/playButton.svg";
 import "./FullAnime.scss";
 import AOS from "aos";
@@ -15,7 +21,11 @@ import {
   useGetAnimeEpisodesQuery,
   useGetAnimePicturesQuery,
   useGetFullAnimeQuery,
+  useLazyGetAnimeRelationsQuery,
   useLazyGetAnimeCharactersQuery,
+  useLazyGetAnimeStreamingQuery,
+  useLazyGetAnimeVideosQuery,
+  useLazyGetCharacterFullQuery,
   useLazyGetAnimeReviewsQuery,
 } from "../../features/apiSlice";
 
@@ -46,6 +56,10 @@ const FullAnime = () => {
   const { id } = useParams();
   const [isActiveCharacters, setIsActiveCharacters] = useState(false)
   const [isActiveReviews, setIsActiveReviews] = useState(false)
+  const [isActiveRelations, setIsActiveRelations] = useState(false)
+  const [isActiveStreaming, setIsActiveStreaming] = useState(false)
+  const [isActiveVideos, setIsActiveVideos] = useState(false)
+  const [selectedCharacter, setSelectedCharacter] = useState(null)
   const {
     data: fullAnimeData,
     isLoading: fullAnimeLoading,
@@ -80,6 +94,42 @@ const FullAnime = () => {
     },
   ] = useLazyGetAnimeCharactersQuery()
   const [
+    triggerAnimeRelations,
+    {
+      data: animeRelations,
+      isLoading: animeRelationsLoading,
+      isFetching: animeRelationsFetching,
+      isError: animeRelationsError,
+    },
+  ] = useLazyGetAnimeRelationsQuery()
+  const [
+    triggerAnimeStreaming,
+    {
+      data: animeStreaming,
+      isLoading: animeStreamingLoading,
+      isFetching: animeStreamingFetching,
+      isError: animeStreamingError,
+    },
+  ] = useLazyGetAnimeStreamingQuery()
+  const [
+    triggerAnimeVideos,
+    {
+      data: animeVideos,
+      isLoading: animeVideosLoading,
+      isFetching: animeVideosFetching,
+      isError: animeVideosError,
+    },
+  ] = useLazyGetAnimeVideosQuery()
+  const [
+    triggerCharacterFull,
+    {
+      data: characterFull,
+      isLoading: characterFullLoading,
+      isFetching: characterFullFetching,
+      isError: characterFullError,
+    },
+  ] = useLazyGetCharacterFullQuery()
+  const [
     triggerAnimeReviews,
     {
       data: animeReviews,
@@ -102,6 +152,9 @@ const FullAnime = () => {
   const pictures = Array.isArray(animePictures?.data) ? animePictures.data : [];
   const episodes = Array.isArray(animeEpisodes?.data) ? animeEpisodes.data : [];
   const characters = Array.isArray(animeCharacters?.data) ? animeCharacters.data : [];
+  const relations = Array.isArray(animeRelations?.data) ? animeRelations.data : [];
+  const streaming = Array.isArray(animeStreaming?.data) ? animeStreaming.data : [];
+  const videos = animeVideos?.data ?? {};
   const reviews = Array.isArray(animeReviews?.data) ? animeReviews.data : [];
   const trailerUrl = anime?.trailer?.url;
   const trailerImageUrl = anime?.trailer?.images?.maximum_image_url;
@@ -128,6 +181,40 @@ const FullAnime = () => {
     if (id) {
       triggerAnimeReviews(id, true);
     }
+  };
+  const handleShowAnimeRelations = () => {
+    setIsActiveRelations(true);
+
+    if (id) {
+      triggerAnimeRelations(id, true);
+    }
+  };
+  const handleShowAnimeStreaming = () => {
+    setIsActiveStreaming(true);
+
+    if (id) {
+      triggerAnimeStreaming(id, true);
+    }
+  };
+  const handleShowAnimeVideos = () => {
+    setIsActiveVideos(true);
+
+    if (id) {
+      triggerAnimeVideos(id, true);
+    }
+  };
+  const handleShowCharacterProfile = (character) => {
+    const characterId = character?.mal_id;
+
+    if (!characterId) {
+      return;
+    }
+
+    setSelectedCharacter({
+      id: characterId,
+      name: character?.name || "Unknown",
+    });
+    triggerCharacterFull(characterId, true);
   };
 
   return (
@@ -207,6 +294,33 @@ const FullAnime = () => {
                 <p className="detail-empty text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl mb-4">No trailer is available for this anime yet.</p>
               )}
             </div>
+            <RelationsPanel
+              isActive={isActiveRelations}
+              isError={animeRelationsError}
+              isFetching={animeRelationsFetching}
+              isLoading={animeRelationsLoading}
+              items={relations}
+              onOpen={handleShowAnimeRelations}
+              onRetry={() => triggerAnimeRelations(id, false)}
+            />
+            <StreamingPanel
+              isActive={isActiveStreaming}
+              isError={animeStreamingError}
+              isFetching={animeStreamingFetching}
+              isLoading={animeStreamingLoading}
+              items={streaming}
+              onOpen={handleShowAnimeStreaming}
+              onRetry={() => triggerAnimeStreaming(id, false)}
+            />
+            <VideosPanel
+              isActive={isActiveVideos}
+              isError={animeVideosError}
+              isFetching={animeVideosFetching}
+              isLoading={animeVideosLoading}
+              items={videos}
+              onOpen={handleShowAnimeVideos}
+              onRetry={() => triggerAnimeVideos(id, false)}
+            />
             <div className="episodes">
               <h2 className="episodes__text detail-section__title text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl my-4">Episodes</h2>
               <div className="episodes__type flex gap-4 items-center">
@@ -269,12 +383,27 @@ const FullAnime = () => {
                           {voiceActors.slice(0, 2).map(actor => (
                             <p key={actor.person?.mal_id || `${actor.language}-${actor.person?.name}`}>{actor.language || "Unknown"} : <b>{actor.person?.name || "Unknown"}</b></p>
                           ))}
+                          <button
+                            type="button"
+                            className="character-profile-button"
+                            onClick={() => handleShowCharacterProfile(character)}
+                          >
+                            Open profile for {characterName}
+                          </button>
                         </div>
                       </div>
                     );
                   })}
                 </div>
               ) : isActiveCharacters ? <p>There are currently no characters for this anime.</p> : null}
+              <CharacterProfilePanel
+                characterName={selectedCharacter?.name}
+                data={characterFull}
+                isError={characterFullError}
+                isFetching={characterFullFetching}
+                isLoading={characterFullLoading}
+                onRetry={() => triggerCharacterFull(selectedCharacter?.id, false)}
+              />
             </div>
             <div className="reviews mt-5">
               <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowAnimeReviews}>Read community reviews</button>

--- a/src/components/FullManga/FullManga.jsx
+++ b/src/components/FullManga/FullManga.jsx
@@ -8,12 +8,18 @@ import { Autoplay } from "swiper/modules";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
 import ReviewCard from "../ReviewCard/ReviewCard";
+import {
+  CharacterProfilePanel,
+  RelationsPanel,
+} from "../JikanDetailExtras/JikanDetailExtras";
 import AOS from "aos";
 import "aos/dist/aos.css";
 import {
   useGetFullMangaQuery,
   useGetMangaPicturesQuery,
   useLazyGetMangaCharactersQuery,
+  useLazyGetMangaRelationsQuery,
+  useLazyGetCharacterFullQuery,
   useLazyGetMangaReviewsQuery,
 } from "../../features/apiSlice";
 
@@ -43,6 +49,8 @@ const swiperBreakpoints = {
 const FullManga = () => {
   const [isActiveCharacters, setIsActiveCharacters] = useState(false);
   const [isActiveReviews, setIsActiveReviews] = useState(false)
+  const [isActiveRelations, setIsActiveRelations] = useState(false)
+  const [selectedCharacter, setSelectedCharacter] = useState(null)
   const { id } = useParams();
 
   const {
@@ -72,6 +80,24 @@ const FullManga = () => {
     },
   ] = useLazyGetMangaCharactersQuery()
   const [
+    triggerMangaRelations,
+    {
+      data: mangaRelations,
+      isLoading: mangaRelationsLoading,
+      isFetching: mangaRelationsFetching,
+      isError: mangaRelationsError,
+    },
+  ] = useLazyGetMangaRelationsQuery()
+  const [
+    triggerCharacterFull,
+    {
+      data: characterFull,
+      isLoading: characterFullLoading,
+      isFetching: characterFullFetching,
+      isError: characterFullError,
+    },
+  ] = useLazyGetCharacterFullQuery()
+  const [
     triggerMangaReviews,
     {
       data: mangaReviews,
@@ -93,6 +119,7 @@ const FullManga = () => {
   const authors = Array.isArray(manga?.authors) ? manga.authors : [];
   const pictures = Array.isArray(mangaPictures?.data) ? mangaPictures.data : [];
   const characters = Array.isArray(mangaCharacters?.data) ? mangaCharacters.data : [];
+  const relations = Array.isArray(mangaRelations?.data) ? mangaRelations.data : [];
   const reviews = Array.isArray(mangaReviews?.data) ? mangaReviews.data : [];
   const showMangaCharactersLoader = isActiveCharacters && (
     mangaCharactersUninitialized ||
@@ -117,6 +144,26 @@ const FullManga = () => {
     if (id) {
       triggerMangaReviews(id, true);
     }
+  };
+  const handleShowMangaRelations = () => {
+    setIsActiveRelations(true);
+
+    if (id) {
+      triggerMangaRelations(id, true);
+    }
+  };
+  const handleShowCharacterProfile = (character) => {
+    const characterId = character?.mal_id;
+
+    if (!characterId) {
+      return;
+    }
+
+    setSelectedCharacter({
+      id: characterId,
+      name: character?.name || "Unknown",
+    });
+    triggerCharacterFull(characterId, true);
   };
 
   return (
@@ -188,6 +235,15 @@ const FullManga = () => {
               ) : <p>There are currently no images for this manga.</p>}
             </div>
           </div>
+          <RelationsPanel
+            isActive={isActiveRelations}
+            isError={mangaRelationsError}
+            isFetching={mangaRelationsFetching}
+            isLoading={mangaRelationsLoading}
+            items={relations}
+            onOpen={handleShowMangaRelations}
+            onRetry={() => triggerMangaRelations(id, false)}
+          />
           <div className="mangaCharacters mt-8">
             <h2 className="mangaCharacters__title detail-section__title text-xl sm:text-xl md:text-xl lg:text-2xl xl:text-2xl mb-3">Characters</h2>
             <button className={isActiveCharacters ? "display-none " : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowMangaCharacters}>Browse character list</button>
@@ -210,12 +266,27 @@ const FullManga = () => {
                       <div className="mangaCharacters__card-textWrapepr p-2">
                         <p className="mangaCharacters__card-text">Name : <b>{characterName}</b></p>
                         <p className="mangaCharacters__card-subText">Role: <b>{obj.role || "Unknown"}</b></p>
+                        <button
+                          type="button"
+                          className="character-profile-button"
+                          onClick={() => handleShowCharacterProfile(character)}
+                        >
+                          Open profile for {characterName}
+                        </button>
                       </div>
                     </div>
                   );
                 })}
               </div>
             ) : isActiveCharacters ? <p>There are currently no characters for this manga.</p> : null}
+            <CharacterProfilePanel
+              characterName={selectedCharacter?.name}
+              data={characterFull}
+              isError={characterFullError}
+              isFetching={characterFullFetching}
+              isLoading={characterFullLoading}
+              onRetry={() => triggerCharacterFull(selectedCharacter?.id, false)}
+            />
           </div>
           <div className="reviews mt-5">
             <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowMangaReviews}>Read community reviews</button>

--- a/src/components/GenreChips/GenreChips.jsx
+++ b/src/components/GenreChips/GenreChips.jsx
@@ -1,0 +1,65 @@
+import PropTypes from "prop-types";
+import ErrorState from "../ErrorState/ErrorState";
+import "./genreChips.scss";
+
+const GenreChips = ({ genres, isError, isFetching, onRetry, selectedGenreId, onSelectGenre, title }) => {
+  const genreItems = Array.isArray(genres) ? genres : [];
+
+  if (isError) {
+    return (
+      <div className="genre-chips">
+        <ErrorState
+          message={`${title} genres could not be loaded.`}
+          onRetry={onRetry}
+          isRetrying={isFetching}
+        />
+      </div>
+    );
+  }
+
+  if (genreItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="genre-chips" aria-label={`${title} genres`}>
+      <div className="genre-chips__header">
+        <span>Browse by genre</span>
+        {selectedGenreId ? (
+          <button type="button" onClick={() => onSelectGenre(null)}>
+            Clear
+          </button>
+        ) : null}
+      </div>
+      <div className="genre-chips__list">
+        {genreItems.slice(0, 14).map((genre) => (
+          <button
+            type="button"
+            key={genre.mal_id}
+            className={selectedGenreId === genre.mal_id ? "genre-chip genre-chip--active" : "genre-chip"}
+            onClick={() => onSelectGenre(genre.mal_id)}
+          >
+            {genre.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+GenreChips.propTypes = {
+  genres: PropTypes.arrayOf(
+    PropTypes.shape({
+      mal_id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ),
+  isError: PropTypes.bool,
+  isFetching: PropTypes.bool,
+  onRetry: PropTypes.func,
+  selectedGenreId: PropTypes.number,
+  onSelectGenre: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default GenreChips;

--- a/src/components/GenreChips/genreChips.scss
+++ b/src/components/GenreChips/genreChips.scss
@@ -1,0 +1,46 @@
+.genre-chips {
+  margin-top: 18px;
+  padding-bottom: 18px;
+}
+
+.genre-chips__header {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  font-size: 0.9rem;
+  font-weight: 750;
+  justify-content: space-between;
+  margin-bottom: 10px;
+
+  button {
+    border: 0;
+    color: var(--accent-cyan);
+    font-weight: 800;
+  }
+}
+
+.genre-chips__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.genre-chip {
+  background: rgba(246, 240, 229, 0.06);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+  min-height: 38px;
+  padding: 8px 11px;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+
+  &:hover,
+  &--active {
+    background: rgba(217, 164, 65, 0.16);
+    border-color: rgba(217, 164, 65, 0.68);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+  }
+}

--- a/src/components/JikanDetailExtras/JikanDetailExtras.jsx
+++ b/src/components/JikanDetailExtras/JikanDetailExtras.jsx
@@ -1,0 +1,213 @@
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import ErrorState from "../ErrorState/ErrorState";
+import LazyLoading from "../LazyLoading/LazyLoading";
+import "./jikanDetailExtras.scss";
+
+export const RelationsPanel = ({ isActive, isError, isFetching, isLoading, items, onOpen, onRetry }) => {
+  const relationItems = Array.isArray(items) ? items : [];
+
+  return (
+    <section className="detail-extra" aria-labelledby="relations-title">
+      <div className="detail-extra__header">
+        <div>
+          <p className="section-kicker">Story map</p>
+          <h2 id="relations-title" className="detail-section__title">Relations</h2>
+        </div>
+        {!isActive ? (
+          <button type="button" className="show-btn" onClick={onOpen}>
+            Explore relations
+          </button>
+        ) : null}
+      </div>
+      {isActive ? (
+        isLoading || isFetching ? (
+          <LazyLoading message="Loading relations..." count={4} />
+        ) : isError ? (
+          <ErrorState message="Relations could not be loaded." onRetry={onRetry} isRetrying={isFetching} />
+        ) : relationItems.length > 0 ? (
+          <div className="detail-extra__relation-grid">
+            {relationItems.map((relation) => {
+              const entries = Array.isArray(relation.entry) ? relation.entry : [];
+
+              return (
+                <article key={relation.relation} className="detail-extra__relation-card">
+                  <h3>{relation.relation || "Related"}</h3>
+                  <div className="detail-extra__links">
+                    {entries.map((entry) => {
+                      const isInternal = entry.type === "anime" || entry.type === "manga";
+                      const target = isInternal ? `/${entry.type}/${entry.mal_id}` : entry.url;
+
+                      return isInternal ? (
+                        <Link key={`${entry.type}-${entry.mal_id}-${entry.name}`} to={target}>
+                          {entry.name || "Untitled relation"}
+                        </Link>
+                      ) : (
+                        <a key={`${entry.type}-${entry.mal_id}-${entry.name}`} href={target} target="_blank" rel="noreferrer">
+                          {entry.name || "Untitled relation"}
+                        </a>
+                      );
+                    })}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="detail-empty">No relations are listed yet.</p>
+        )
+      ) : null}
+    </section>
+  );
+};
+
+export const StreamingPanel = ({ isActive, isError, isFetching, isLoading, items, onOpen, onRetry }) => {
+  const streamingItems = Array.isArray(items) ? items : [];
+
+  return (
+    <section className="detail-extra" aria-labelledby="streaming-title">
+      <div className="detail-extra__header">
+        <div>
+          <p className="section-kicker">Where to watch</p>
+          <h2 id="streaming-title" className="detail-section__title">Streaming</h2>
+        </div>
+        {!isActive ? (
+          <button type="button" className="show-btn" onClick={onOpen}>
+            Find streams
+          </button>
+        ) : null}
+      </div>
+      {isActive ? (
+        isLoading || isFetching ? (
+          <LazyLoading message="Loading streaming providers..." count={3} />
+        ) : isError ? (
+          <ErrorState message="Streaming links could not be loaded." onRetry={onRetry} isRetrying={isFetching} />
+        ) : streamingItems.length > 0 ? (
+          <div className="detail-extra__pill-grid">
+            {streamingItems.map((item) => (
+              <a key={`${item.name}-${item.url}`} href={item.url} target="_blank" rel="noreferrer">
+                {item.name || "Streaming provider"}
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p className="detail-empty">No streaming providers are listed yet.</p>
+        )
+      ) : null}
+    </section>
+  );
+};
+
+export const VideosPanel = ({ isActive, isError, isFetching, isLoading, items, onOpen, onRetry }) => {
+  const videoItems = Array.isArray(items?.promo) ? items.promo : [];
+
+  return (
+    <section className="detail-extra" aria-labelledby="videos-title">
+      <div className="detail-extra__header">
+        <div>
+          <p className="section-kicker">Official media</p>
+          <h2 id="videos-title" className="detail-section__title">Videos</h2>
+        </div>
+        {!isActive ? (
+          <button type="button" className="show-btn" onClick={onOpen}>
+            Watch videos
+          </button>
+        ) : null}
+      </div>
+      {isActive ? (
+        isLoading || isFetching ? (
+          <LazyLoading message="Loading videos..." count={3} />
+        ) : isError ? (
+          <ErrorState message="Videos could not be loaded." onRetry={onRetry} isRetrying={isFetching} />
+        ) : videoItems.length > 0 ? (
+          <div className="detail-extra__video-grid">
+            {videoItems.map((item) => {
+              const title = item.title || "Anime video";
+              const imageUrl = item.trailer?.images?.image_url;
+              const url = item.trailer?.url;
+
+              return url ? (
+                <a key={`${title}-${url}`} href={url} target="_blank" rel="noreferrer" className="detail-extra__video-card">
+                  {imageUrl ? <img src={imageUrl} alt="" /> : null}
+                  <span>{title}</span>
+                </a>
+              ) : null;
+            })}
+          </div>
+        ) : (
+          <p className="detail-empty">No official videos are listed yet.</p>
+        )
+      ) : null}
+    </section>
+  );
+};
+
+export const CharacterProfilePanel = ({ characterName, data, isError, isFetching, isLoading, onRetry }) => {
+  const character = data?.data;
+
+  if (!characterName) {
+    return null;
+  }
+
+  return (
+    <aside className="character-profile" aria-live="polite">
+      {isLoading || isFetching ? (
+        <LazyLoading message="Loading character profile..." count={2} />
+      ) : isError ? (
+        <ErrorState message="Character profile could not be loaded." onRetry={onRetry} isRetrying={isFetching} />
+      ) : character ? (
+        <>
+          <div className="character-profile__media">
+            {character.images?.webp?.image_url ? <img src={character.images.webp.image_url} alt={character.name || characterName} /> : null}
+          </div>
+          <div className="character-profile__body">
+            <p className="section-kicker">Character profile</p>
+            <h2>{character.name || characterName}</h2>
+            {character.name_kanji ? <p className="character-profile__kanji">{character.name_kanji}</p> : null}
+            <p className="character-profile__meta">Favorites: <b>{character.favorites ?? "Unknown"}</b></p>
+            <p className="character-profile__about">{character.about || "No character biography is available yet."}</p>
+          </div>
+        </>
+      ) : (
+        <p className="detail-empty">Character profile is empty.</p>
+      )}
+    </aside>
+  );
+};
+
+const queryStatePropTypes = {
+  isActive: PropTypes.bool.isRequired,
+  isError: PropTypes.bool,
+  isFetching: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onOpen: PropTypes.func.isRequired,
+  onRetry: PropTypes.func.isRequired,
+};
+
+RelationsPanel.propTypes = {
+  ...queryStatePropTypes,
+  items: PropTypes.arrayOf(PropTypes.object),
+};
+
+StreamingPanel.propTypes = {
+  ...queryStatePropTypes,
+  items: PropTypes.arrayOf(PropTypes.object),
+};
+
+VideosPanel.propTypes = {
+  ...queryStatePropTypes,
+  items: PropTypes.shape({
+    promo: PropTypes.arrayOf(PropTypes.object),
+  }),
+};
+
+CharacterProfilePanel.propTypes = {
+  characterName: PropTypes.string,
+  data: PropTypes.shape({
+    data: PropTypes.object,
+  }),
+  isError: PropTypes.bool,
+  isFetching: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onRetry: PropTypes.func.isRequired,
+};

--- a/src/components/JikanDetailExtras/jikanDetailExtras.scss
+++ b/src/components/JikanDetailExtras/jikanDetailExtras.scss
@@ -1,0 +1,152 @@
+.detail-extra,
+.character-profile {
+  background: rgba(28, 26, 23, 0.66);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  margin-top: 24px;
+  padding: clamp(18px, 3vw, 28px);
+  position: relative;
+  z-index: 2;
+}
+
+.detail-extra__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.detail-extra__relation-grid,
+.detail-extra__video-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.detail-extra__relation-card,
+.detail-extra__video-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 42%), var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  min-width: 0;
+  padding: 16px;
+}
+
+.detail-extra__relation-card h3 {
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 900;
+  margin-bottom: 10px;
+}
+
+.detail-extra__links,
+.detail-extra__pill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.detail-extra__links a,
+.detail-extra__pill-grid a {
+  background: rgba(246, 240, 229, 0.06);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 800;
+  padding: 9px 11px;
+  transition: border-color 160ms ease, background 160ms ease;
+
+  &:hover {
+    background: rgba(134, 215, 198, 0.12);
+    border-color: rgba(134, 215, 198, 0.5);
+  }
+}
+
+.detail-extra__video-card {
+  color: var(--text-primary);
+  display: grid;
+  gap: 10px;
+  font-weight: 850;
+
+  img {
+    aspect-ratio: 16 / 9;
+    border-radius: var(--radius);
+    object-fit: cover;
+    width: 100%;
+  }
+}
+
+.character-profile {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+}
+
+.character-profile__media {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  min-height: 180px;
+  overflow: hidden;
+
+  img {
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+  }
+}
+
+.character-profile__body {
+  min-width: 0;
+
+  h2 {
+    color: var(--text-primary);
+    font-size: clamp(1.5rem, 3vw, 2.2rem);
+    font-weight: 900;
+    line-height: 1.1;
+  }
+}
+
+.character-profile__kanji,
+.character-profile__meta,
+.character-profile__about {
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+.character-profile__about {
+  line-height: 1.7;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.character-profile-button {
+  background: rgba(134, 215, 198, 0.12);
+  border: 1px solid rgba(134, 215, 198, 0.5);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-weight: 850;
+  margin-top: 12px;
+  min-height: 38px;
+  padding: 8px 10px;
+  width: 100%;
+}
+
+@media (max-width: 820px) {
+  .detail-extra__header,
+  .character-profile {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-extra__header {
+    display: grid;
+  }
+
+  .detail-extra__relation-grid,
+  .detail-extra__video-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/MangaSearch/MangaSearch.jsx
+++ b/src/components/MangaSearch/MangaSearch.jsx
@@ -1,17 +1,19 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
-import { useGetMangaSearchQuery } from "../../features/apiSlice";
+import { useGetMangaGenresQuery, useGetMangaSearchQuery } from "../../features/apiSlice";
 import useDebounce from "../../hooks/useDebounce";
 import Filter from "../Filter/Filter";
 import Sort from "../Filter/Sort";
 import MangaCard from "../MangaCard/MangaCard.jsx";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
+import GenreChips from "../GenreChips/GenreChips";
 import "./mangaSearch.scss";
 
 const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy, showMediaToggle = true }) => {
   const [queryManga, setQueryManga] = useState("");
+  const [selectedGenreId, setSelectedGenreId] = useState(null);
   const debouncedQuery = useDebounce(queryManga, 500);
 
   const {
@@ -20,7 +22,13 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy, showMediaToggle =
     isFetching,
     isError,
     refetch,
-  } = useGetMangaSearchQuery({ orderBy, sortBy, query: debouncedQuery });
+  } = useGetMangaSearchQuery({ orderBy, sortBy, query: debouncedQuery, genreId: selectedGenreId });
+  const {
+    data: mangaGenres,
+    isFetching: mangaGenresFetching,
+    isError: mangaGenresError,
+    refetch: refetchMangaGenres,
+  } = useGetMangaGenresQuery();
   const mangaSearchItems = mangaSearch?.data ?? [];
 
   return (
@@ -44,7 +52,7 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy, showMediaToggle =
       <div className="filter search-filters">
         <div className="search-filters__summary">
           <span>Current shelf</span>
-          <strong>{orderBy} / {sortBy}</strong>
+          <strong>{orderBy} / {sortBy}{selectedGenreId ? " / genre" : ""}</strong>
         </div>
         <div className="search-filters__group">
           <p>Order by</p>
@@ -55,6 +63,15 @@ const MangaSearch = ({ orderBy, setOrderBy, setSortBy, sortBy, showMediaToggle =
           <Sort setSortBy={setSortBy} />
         </div>
       </div>
+      <GenreChips
+        title="Manga"
+        genres={mangaGenres?.data ?? []}
+        isError={mangaGenresError}
+        isFetching={mangaGenresFetching}
+        onRetry={refetchMangaGenres}
+        selectedGenreId={selectedGenreId}
+        onSelectGenre={setSelectedGenreId}
+      />
       <div className="search-content catalogue-grid">
         {isLoading ? (
           <LazyLoading message="Loading manga matches..." count={8} />

--- a/src/components/SeasonalSpotlight/SeasonalSpotlight.jsx
+++ b/src/components/SeasonalSpotlight/SeasonalSpotlight.jsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import AnimeCard from "../AnimeCard/AnimeCard";
+import ErrorState from "../ErrorState/ErrorState";
+import LazyLoading from "../LazyLoading/LazyLoading";
+import {
+  useLazyGetSchedulesQuery,
+  useLazyGetSeasonNowQuery,
+  useLazyGetSeasonUpcomingQuery,
+} from "../../features/apiSlice";
+import "./seasonalSpotlight.scss";
+
+const tabs = [
+  { key: "now", label: "Now" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "schedule", label: "Schedule" },
+];
+
+const SeasonalGrid = ({ items }) => {
+  if (items.length === 0) {
+    return <p className="seasonal-spotlight__empty">No seasonal titles are available right now.</p>;
+  }
+
+  return (
+    <div className="seasonal-spotlight__grid">
+      {items.slice(0, 5).map((item) => (
+        <Link key={item.mal_id} to={`/anime/${item.mal_id}`}>
+          <AnimeCard {...item} />
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+SeasonalGrid.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+const SeasonalSpotlight = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("now");
+  const [
+    triggerSeasonNow,
+    {
+      data: seasonNow,
+      isLoading: seasonNowLoading,
+      isFetching: seasonNowFetching,
+      isError: seasonNowError,
+    },
+  ] = useLazyGetSeasonNowQuery();
+  const [
+    triggerSeasonUpcoming,
+    {
+      data: seasonUpcoming,
+      isLoading: seasonUpcomingLoading,
+      isFetching: seasonUpcomingFetching,
+      isError: seasonUpcomingError,
+    },
+  ] = useLazyGetSeasonUpcomingQuery();
+  const [
+    triggerSchedules,
+    {
+      data: schedules,
+      isLoading: schedulesLoading,
+      isFetching: schedulesFetching,
+      isError: schedulesError,
+    },
+  ] = useLazyGetSchedulesQuery();
+
+  const loadTab = (tabKey, preferCache = true) => {
+    if (tabKey === "now") {
+      triggerSeasonNow(undefined, preferCache);
+    } else if (tabKey === "upcoming") {
+      triggerSeasonUpcoming(undefined, preferCache);
+    } else {
+      triggerSchedules({ filter: "monday" }, preferCache);
+    }
+  };
+
+  const handleOpen = () => {
+    setIsOpen(true);
+    loadTab(activeTab);
+  };
+
+  const handleTabClick = (tabKey) => {
+    setActiveTab(tabKey);
+    loadTab(tabKey);
+  };
+
+  const activeState = {
+    now: {
+      data: seasonNow,
+      isLoading: seasonNowLoading,
+      isFetching: seasonNowFetching,
+      isError: seasonNowError,
+      retry: () => triggerSeasonNow(undefined, false),
+    },
+    upcoming: {
+      data: seasonUpcoming,
+      isLoading: seasonUpcomingLoading,
+      isFetching: seasonUpcomingFetching,
+      isError: seasonUpcomingError,
+      retry: () => triggerSeasonUpcoming(undefined, false),
+    },
+    schedule: {
+      data: schedules,
+      isLoading: schedulesLoading,
+      isFetching: schedulesFetching,
+      isError: schedulesError,
+      retry: () => triggerSchedules({ filter: "monday" }, false),
+    },
+  }[activeTab];
+  const items = Array.isArray(activeState.data?.data) ? activeState.data.data : [];
+
+  return (
+    <section className="seasonal-spotlight" aria-labelledby="seasonal-spotlight-title">
+      <div className="section-heading">
+        <p className="section-kicker">Airing calendar</p>
+        <h2 id="seasonal-spotlight-title" className="TopAnime__title">Seasonal spotlight</h2>
+      </div>
+      <p className="seasonal-spotlight__copy">
+        Check what is airing now, what is coming next, and what is scheduled this week without leaving the anime shelf.
+      </p>
+      {!isOpen ? (
+        <button type="button" className="show-btn" onClick={handleOpen}>
+          Open seasonal spotlight
+        </button>
+      ) : (
+        <>
+          <div className="seasonal-spotlight__tabs" aria-label="Seasonal spotlight views">
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                className={activeTab === tab.key ? "seasonal-spotlight__tab seasonal-spotlight__tab--active" : "seasonal-spotlight__tab"}
+                onClick={() => handleTabClick(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          {activeState.isLoading || activeState.isFetching ? (
+            <LazyLoading message="Loading seasonal anime..." count={5} />
+          ) : activeState.isError ? (
+            <ErrorState
+              message="Seasonal anime could not be loaded."
+              onRetry={activeState.retry}
+              isRetrying={activeState.isFetching}
+            />
+          ) : (
+            <SeasonalGrid items={items} />
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default SeasonalSpotlight;

--- a/src/components/SeasonalSpotlight/seasonalSpotlight.scss
+++ b/src/components/SeasonalSpotlight/seasonalSpotlight.scss
@@ -1,0 +1,61 @@
+.seasonal-spotlight {
+  background: rgba(28, 26, 23, 0.66);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  margin: 24px 0;
+  padding: clamp(18px, 3vw, 28px);
+}
+
+.seasonal-spotlight__copy,
+.seasonal-spotlight__empty {
+  color: var(--text-muted);
+  margin-bottom: 18px;
+  max-width: 760px;
+}
+
+.seasonal-spotlight__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.seasonal-spotlight__tab {
+  background: rgba(246, 240, 229, 0.06);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-weight: 850;
+  min-height: 40px;
+  padding: 9px 14px;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+
+  &:hover,
+  &--active {
+    background: rgba(134, 215, 198, 0.13);
+    border-color: rgba(134, 215, 198, 0.58);
+    color: var(--text-primary);
+  }
+}
+
+.seasonal-spotlight__grid {
+  display: grid;
+  gap: clamp(14px, 2vw, 20px);
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+
+  > * {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 1119px) {
+  .seasonal-spotlight__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .seasonal-spotlight__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/features/apiSlice.js
+++ b/src/features/apiSlice.js
@@ -26,7 +26,10 @@ const isTransientJikanError = (error) => {
 };
 
 const staggeredBaseQuery = retry(
-  fetchBaseQuery({ baseUrl: 'https://api.jikan.moe/v4' }),
+  fetchBaseQuery({
+    baseUrl: 'https://api.jikan.moe/v4',
+    timeout: 15000,
+  }),
   {
     maxRetries: 2,
     retryCondition: (error) => isTransientJikanError(error),
@@ -85,20 +88,55 @@ export const fetchDataApi = createApi({
     }),
 
     getAnimeSearch: builder.query({
-      query: ({ orderBy, rating, sortBy, query }) => buildSearchQuery("anime", {
+      query: ({ orderBy, rating, sortBy, query, genreId }) => buildSearchQuery("anime", {
         order_by: orderBy,
         rating,
         sort: sortBy,
         q: query,
+        genres: genreId,
       }),
     }),
 
     getMangaSearch: builder.query({
-      query: ({ orderBy, sortBy, query }) => buildSearchQuery("manga", {
+      query: ({ orderBy, sortBy, query, genreId }) => buildSearchQuery("manga", {
         order_by: orderBy,
         sort: sortBy,
         q: query,
+        genres: genreId,
       }),
+    }),
+
+    getSeasonNow: builder.query({
+      query: () => '/seasons/now',
+    }),
+    getSeasonUpcoming: builder.query({
+      query: () => '/seasons/upcoming',
+    }),
+    getSchedules: builder.query({
+      query: ({ filter } = {}) => buildSearchQuery("schedules", { filter }),
+    }),
+
+    getAnimeGenres: builder.query({
+      query: () => '/genres/anime',
+    }),
+    getMangaGenres: builder.query({
+      query: () => '/genres/manga',
+    }),
+
+    getAnimeRelations: builder.query({
+      query: (id) => `/anime/${id}/relations`,
+    }),
+    getAnimeStreaming: builder.query({
+      query: (id) => `/anime/${id}/streaming`,
+    }),
+    getAnimeVideos: builder.query({
+      query: (id) => `/anime/${id}/videos`,
+    }),
+    getMangaRelations: builder.query({
+      query: (id) => `/manga/${id}/relations`,
+    }),
+    getCharacterFull: builder.query({
+      query: (id) => `/characters/${id}`,
     }),
 
   })
@@ -133,4 +171,17 @@ export const {
 
   useGetAnimeSearchQuery,
   useGetMangaSearchQuery,
+
+  useLazyGetSeasonNowQuery,
+  useLazyGetSeasonUpcomingQuery,
+  useLazyGetSchedulesQuery,
+
+  useGetAnimeGenresQuery,
+  useGetMangaGenresQuery,
+
+  useLazyGetAnimeRelationsQuery,
+  useLazyGetAnimeStreamingQuery,
+  useLazyGetAnimeVideosQuery,
+  useLazyGetMangaRelationsQuery,
+  useLazyGetCharacterFullQuery,
 } = fetchDataApi;


### PR DESCRIPTION
## Summary
- Add genre chips and endpoint-aware search filtering for anime and manga
- Surface seasonal spotlight content on the anime page
- Expand detail pages with relations, streaming, videos, and character profile panels
- Update RTK Query endpoints and PWA fixtures to cover the new Jikan flows

## Testing
- Not run (not requested)