### PR TITLE
Add local library support

### DIFF
--- a/e2e/user-library.spec.js
+++ b/e2e/user-library.spec.js
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+const routeJikanDetail = async (page) => {
+  await page.route('https://api.jikan.moe/v4/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const { pathname } = requestUrl;
+    let body = { data: [] };
+
+    if (pathname === '/v4/anime/1') {
+      body = {
+        data: {
+          mal_id: 1,
+          title: 'Library Anime Fixture',
+          score: 9.2,
+          episodes: 12,
+          status: 'Finished Airing',
+          year: 2026,
+          rating: 'PG-13',
+          studios: [{ mal_id: 1, name: 'Library Studio' }],
+          images: { webp: {} },
+          trailer: { url: null, images: {} },
+        },
+      };
+    } else if (pathname === '/v4/anime/1/pictures' || pathname === '/v4/anime/1/episodes') {
+      body = { data: [] };
+    }
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+};
+
+test.beforeEach(async ({ page }) => {
+  await routeJikanDetail(page);
+});
+
+test('saved anime persists in the local library and renders offline', async ({ page, context }) => {
+  await page.goto('/anime/1');
+
+  await expect(page.getByRole('heading', { name: 'Library Anime Fixture' })).toBeVisible();
+  await page.getByRole('button', { name: 'Save to library' }).click();
+  await page.getByLabel('Library status').selectOption('completed');
+  await page.getByRole('button', { name: 'Mark as favorite' }).click();
+
+  await page.getByRole('link', { name: 'Library' }).click();
+  await expect(page.getByRole('heading', { name: 'Your library' })).toBeVisible();
+  const savedCard = page.getByRole('link', { name: /Library Anime Fixture/i });
+  await expect(savedCard).toBeVisible();
+  await expect(savedCard.getByText('Completed')).toBeVisible();
+  await expect(savedCard.getByText('Favorite')).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole('link', { name: /Library Anime Fixture/i })).toBeVisible();
+
+  await context.setOffline(true);
+
+  try {
+    await page.goto('/library');
+    await expect(page.getByRole('link', { name: /Library Anime Fixture/i })).toBeVisible();
+    await page.getByRole('button', { name: 'Favorites only' }).click();
+    await expect(page.getByRole('link', { name: /Library Anime Fixture/i })).toBeVisible();
+  } finally {
+    await context.setOffline(false);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "harness:check": "node scripts/verify-harness-docs.mjs",
+    "library:check": "node scripts/verify-user-library.mjs",
     "pwa:check": "node scripts/verify-pwa.mjs",
     "pwa:dist-check": "node scripts/verify-pwa-dist.mjs",
     "pwa:e2e": "playwright test",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "verify": "npm run harness:check && npm run pwa:check && npm run lint && npm run build && npm run pwa:dist-check && npm run pwa:e2e"
+    "verify": "npm run harness:check && npm run library:check && npm run pwa:check && npm run lint && npm run build && npm run pwa:dist-check && npm run pwa:e2e"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.11.2",

--- a/scripts/verify-user-library.mjs
+++ b/scripts/verify-user-library.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+
+import {
+  USER_LIBRARY_STORAGE_KEY,
+  addOrUpdateLibraryItem,
+  getLibraryItems,
+  removeLibraryItem,
+  toggleLibraryFavorite,
+  updateLibraryStatus,
+} from '../src/features/userLibrary.js';
+
+const createMemoryStorage = (initialValue) => {
+  const values = new Map();
+
+  if (initialValue !== undefined) {
+    values.set(USER_LIBRARY_STORAGE_KEY, initialValue);
+  }
+
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  };
+};
+
+const animeSnapshot = {
+  id: 1,
+  type: 'anime',
+  title: 'Cowboy Bebop',
+  imageUrl: 'https://example.com/bebop.webp',
+  score: 8.9,
+  route: '/anime/1',
+};
+
+const mangaSnapshot = {
+  id: 2,
+  type: 'manga',
+  title: 'Yotsuba&!',
+  imageUrl: 'https://example.com/yotsuba.webp',
+  score: 8.8,
+  route: '/manga/2',
+};
+
+const corruptStorage = createMemoryStorage('{not valid json');
+assert.deepEqual(getLibraryItems(corruptStorage), []);
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: Object.defineProperty({}, 'localStorage', {
+    get: () => {
+      throw new Error('localStorage denied');
+    },
+  }),
+});
+assert.deepEqual(getLibraryItems(), []);
+
+if (originalWindowDescriptor) {
+  Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+} else {
+  delete globalThis.window;
+}
+
+const storage = createMemoryStorage();
+const firstSave = addOrUpdateLibraryItem(storage, animeSnapshot, {
+  status: 'watching',
+  favorite: true,
+  now: '2026-04-27T10:00:00.000Z',
+});
+assert.equal(firstSave.length, 1);
+assert.equal(firstSave[0].status, 'watching');
+assert.equal(firstSave[0].favorite, true);
+assert.equal(firstSave[0].savedAt, '2026-04-27T10:00:00.000Z');
+assert.equal(firstSave[0].updatedAt, '2026-04-27T10:00:00.000Z');
+
+const secondSave = addOrUpdateLibraryItem(storage, {
+  ...animeSnapshot,
+  title: 'Cowboy Bebop: Complete',
+}, {
+  status: 'completed',
+  now: '2026-04-27T10:05:00.000Z',
+});
+assert.equal(secondSave.length, 1);
+assert.equal(secondSave[0].title, 'Cowboy Bebop: Complete');
+assert.equal(secondSave[0].status, 'completed');
+assert.equal(secondSave[0].favorite, true);
+assert.equal(secondSave[0].savedAt, '2026-04-27T10:00:00.000Z');
+assert.equal(secondSave[0].updatedAt, '2026-04-27T10:05:00.000Z');
+
+addOrUpdateLibraryItem(storage, mangaSnapshot, {
+  status: 'planning',
+  favorite: false,
+  now: '2026-04-27T10:10:00.000Z',
+});
+assert.equal(getLibraryItems(storage).length, 2);
+
+const toggled = toggleLibraryFavorite(storage, 'manga', 2, {
+  now: '2026-04-27T10:12:00.000Z',
+});
+const toggledManga = toggled.find((item) => item.type === 'manga' && item.id === 2);
+assert.equal(toggledManga.favorite, true);
+assert.equal(toggledManga.status, 'planning');
+
+const updated = updateLibraryStatus(storage, 'manga', 2, 'completed', {
+  now: '2026-04-27T10:15:00.000Z',
+});
+const completedManga = updated.find((item) => item.type === 'manga' && item.id === 2);
+assert.equal(completedManga.status, 'completed');
+assert.equal(completedManga.favorite, true);
+
+const removed = removeLibraryItem(storage, 'anime', 1);
+assert.equal(removed.length, 1);
+assert.equal(removed[0].type, 'manga');
+
+console.log('User library storage checks passed.');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Manga from './Page/Manga';
 import FullManga from './components/FullManga/FullManga';
 import GeneralPage from './Page/GeneralPage';
 import About from './Page/About';
+import Library from './Page/Library';
 
 
 const App = () => {
@@ -19,6 +20,7 @@ const App = () => {
           <Route path="/anime/:id" element={<FullAnime />} />
           <Route path="/manga" element={<Manga />} />
           <Route path="/manga/:id" element={<FullManga />} />
+          <Route path="/library" element={<Library />} />
           <Route path="/about" element={<About />} />
           <Route path="*" element={<Navigate to="/" />} />
         </Route>

--- a/src/Page/Library.jsx
+++ b/src/Page/Library.jsx
@@ -1,0 +1,128 @@
+import { Link } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useUserLibrary } from "../features/userLibrary";
+import "./Library.scss";
+
+const typeFilters = [
+  { value: "all", label: "All" },
+  { value: "anime", label: "Anime" },
+  { value: "manga", label: "Manga" },
+];
+
+const statusFilters = [
+  { value: "all", label: "All statuses" },
+  { value: "watching", label: "Watching / Reading" },
+  { value: "planning", label: "Planned" },
+  { value: "completed", label: "Completed" },
+  { value: "dropped", label: "Dropped" },
+];
+
+const statusLabels = {
+  anime: {
+    watching: "Watching",
+    planning: "Plan to watch",
+    completed: "Completed",
+    dropped: "Dropped",
+  },
+  manga: {
+    watching: "Reading",
+    planning: "Plan to read",
+    completed: "Completed",
+    dropped: "Dropped",
+  },
+};
+
+const Library = () => {
+  const { items } = useUserLibrary();
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const filteredItems = useMemo(() => (
+    items
+      .filter((item) => typeFilter === "all" || item.type === typeFilter)
+      .filter((item) => statusFilter === "all" || item.status === statusFilter)
+      .filter((item) => !favoritesOnly || item.favorite)
+      .sort((firstItem, secondItem) => new Date(secondItem.updatedAt) - new Date(firstItem.updatedAt))
+  ), [favoritesOnly, items, statusFilter, typeFilter]);
+
+  return (
+    <main className="library-page">
+      <section className="library-hero">
+        <div>
+          <p className="section-kicker">Offline shelf</p>
+          <h1>Your library</h1>
+          <p>Saved anime and manga stay on this device, so the PWA can show your shelf even without a network connection.</p>
+        </div>
+      </section>
+
+      <section className="library-filters" aria-label="Library filters">
+        <div className="library-filters__group" aria-label="Filter by media type">
+          {typeFilters.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              className={typeFilter === filter.value ? "library-filter library-filter--active" : "library-filter"}
+              aria-pressed={typeFilter === filter.value}
+              onClick={() => setTypeFilter(filter.value)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+        <label className="library-filters__select">
+          <span>Status</span>
+          <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+            {statusFilters.map((filter) => (
+              <option key={filter.value} value={filter.value}>{filter.label}</option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className={favoritesOnly ? "library-filter library-filter--active" : "library-filter"}
+          aria-pressed={favoritesOnly}
+          onClick={() => setFavoritesOnly((value) => !value)}
+        >
+          Favorites only
+        </button>
+      </section>
+
+      {filteredItems.length > 0 ? (
+        <section className="library-grid" aria-label="Saved library items">
+          {filteredItems.map((item) => {
+            const label = statusLabels[item.type][item.status];
+
+            return (
+              <Link className="library-card" key={`${item.type}-${item.id}`} to={item.route}>
+                <div className="library-card__image">
+                  {item.imageUrl ? <img src={item.imageUrl} alt="" /> : <span>{item.type}</span>}
+                </div>
+                <div className="library-card__body">
+                  <p className="library-card__type">{item.type}</p>
+                  <h2>{item.title}</h2>
+                  <div className="library-card__meta">
+                    <span>{label}</span>
+                    {item.score ? <span>Score {item.score}</span> : null}
+                    {item.favorite ? <strong>Favorite</strong> : null}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </section>
+      ) : (
+        <section className="library-empty">
+          <p className="section-kicker">No saved titles</p>
+          <h2>Your shelf is empty.</h2>
+          <p>Open an anime or manga detail page and save it here for quick local access.</p>
+          <div className="library-empty__actions">
+            <Link to="/anime">Browse anime</Link>
+            <Link to="/manga">Browse manga</Link>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+};
+
+export default Library;

--- a/src/Page/Library.scss
+++ b/src/Page/Library.scss
@@ -1,0 +1,219 @@
+.library-page {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(24px, 5vw, 52px) clamp(16px, 3vw, 28px) 64px;
+}
+
+.library-hero {
+  border-bottom: 1px solid var(--surface-border);
+  margin-bottom: 20px;
+  padding-bottom: 22px;
+
+  h1 {
+    color: var(--text-primary);
+    font-size: clamp(2rem, 4vw, 3.7rem);
+    font-weight: 900;
+    line-height: 1;
+    margin: 8px 0 12px;
+  }
+
+  p:not(.section-kicker) {
+    color: var(--text-muted);
+    max-width: 680px;
+  }
+}
+
+.library-filters {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.library-filters__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.library-filter {
+  background: rgba(246, 240, 229, 0.06);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-weight: 800;
+  min-height: 42px;
+  padding: 9px 13px;
+  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+
+  &:hover,
+  &--active {
+    background: rgba(217, 164, 65, 0.16);
+    border-color: rgba(217, 164, 65, 0.55);
+    color: var(--text-primary);
+  }
+}
+
+.library-filters__select {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+
+  span {
+    color: var(--text-subtle);
+    font-size: 0.75rem;
+    font-weight: 850;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  select {
+    background: rgba(12, 12, 11, 0.72);
+    border: 1px solid var(--surface-border-strong);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    min-height: 42px;
+    padding: 9px 12px;
+  }
+}
+
+.library-grid {
+  display: grid;
+  gap: clamp(14px, 2vw, 20px);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.library-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 40%), var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  min-height: 160px;
+  overflow: hidden;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+
+  &:hover {
+    border-color: rgba(217, 164, 65, 0.38);
+    box-shadow: var(--shadow-lift);
+    transform: translateY(-2px);
+  }
+}
+
+.library-card__image {
+  align-items: center;
+  aspect-ratio: 2 / 2.8;
+  background: var(--surface-strong);
+  color: var(--text-subtle);
+  display: flex;
+  font-size: 0.72rem;
+  font-weight: 900;
+  justify-content: center;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+
+  img {
+    display: block;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+  }
+}
+
+.library-card__body {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+
+  h2 {
+    color: var(--text-primary);
+    font-size: 1.08rem;
+    font-weight: 900;
+    line-height: 1.25;
+  }
+}
+
+.library-card__type {
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.library-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  span,
+  strong {
+    border: 1px solid rgba(240, 220, 184, 0.1);
+    border-radius: 999px;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    padding: 5px 8px;
+  }
+
+  strong {
+    background: rgba(134, 215, 198, 0.14);
+    border-color: rgba(134, 215, 198, 0.32);
+    color: var(--text-primary);
+  }
+}
+
+.library-empty {
+  background: rgba(28, 26, 23, 0.72);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 12px;
+  padding: clamp(24px, 4vw, 36px);
+
+  h2 {
+    color: var(--text-primary);
+    font-size: clamp(1.5rem, 3vw, 2.2rem);
+    font-weight: 900;
+  }
+
+  p:not(.section-kicker) {
+    color: var(--text-muted);
+  }
+}
+
+.library-empty__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+
+  a {
+    background: rgba(217, 164, 65, 0.16);
+    border: 1px solid rgba(217, 164, 65, 0.45);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    font-weight: 850;
+    min-height: 42px;
+    padding: 10px 13px;
+  }
+}
+
+@media (min-width: 700px) {
+  .library-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1080px) {
+  .library-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .library-card {
+    grid-template-columns: 92px minmax(0, 1fr);
+  }
+}

--- a/src/components/FullAnime/FullAnime.jsx
+++ b/src/components/FullAnime/FullAnime.jsx
@@ -13,6 +13,7 @@ import {
   StreamingPanel,
   VideosPanel,
 } from "../JikanDetailExtras/JikanDetailExtras";
+import LibraryControls from "../LibraryControls/LibraryControls";
 import playButton from "../../assets/images/playButton.svg";
 import "./FullAnime.scss";
 import AOS from "aos";
@@ -247,6 +248,7 @@ const FullAnime = () => {
                     {studios.length > 0 ? studios.map(studio => <span key={studio.mal_id}>{studio.name}</span>) : "Unknown"}
                   </b>
                 </p>
+                <LibraryControls item={anime} type="anime" />
               </div>
             </div>
             <div className="images" data-aos="fade-up">

--- a/src/components/FullManga/FullManga.jsx
+++ b/src/components/FullManga/FullManga.jsx
@@ -12,6 +12,7 @@ import {
   CharacterProfilePanel,
   RelationsPanel,
 } from "../JikanDetailExtras/JikanDetailExtras";
+import LibraryControls from "../LibraryControls/LibraryControls";
 import AOS from "aos";
 import "aos/dist/aos.css";
 import {
@@ -197,6 +198,7 @@ const FullManga = () => {
                   ))) : <b>Unknown</b>
                 }
               </div>
+              <LibraryControls item={manga} type="manga" />
             </div>
           </div>
           <div data-aos="fade-up" className="fullManga__descr mt-3">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -11,6 +11,7 @@ const Header = () => {
   const navItems = [
     { to: "/anime", label: "Anime" },
     { to: "/manga", label: "Manga" },
+    { to: "/library", label: "Library" },
     { to: "/about", label: "About" },
   ];
 

--- a/src/components/LibraryControls/LibraryControls.jsx
+++ b/src/components/LibraryControls/LibraryControls.jsx
@@ -1,0 +1,110 @@
+import PropTypes from "prop-types";
+import {
+  createLibrarySnapshot,
+  useUserLibrary,
+} from "../../features/userLibrary";
+import "./libraryControls.scss";
+
+const statusLabels = {
+  anime: {
+    watching: "Watching",
+    planning: "Plan to watch",
+    completed: "Completed",
+    dropped: "Dropped",
+  },
+  manga: {
+    watching: "Reading",
+    planning: "Plan to read",
+    completed: "Completed",
+    dropped: "Dropped",
+  },
+};
+
+const LibraryControls = ({ item, type }) => {
+  const { getItem, removeItem, saveItem, toggleFavorite, updateStatus } = useUserLibrary();
+  const itemId = item?.mal_id;
+  const savedItem = getItem(type, itemId);
+  const currentStatus = savedItem?.status ?? "planning";
+  const labels = statusLabels[type];
+  const snapshot = createLibrarySnapshot(item, type);
+
+  const handleSave = () => {
+    saveItem(snapshot, {
+      status: currentStatus,
+      favorite: savedItem?.favorite ?? false,
+    });
+  };
+
+  const handleRemove = () => {
+    removeItem(type, itemId);
+  };
+
+  const handleStatusChange = (event) => {
+    const nextStatus = event.target.value;
+
+    if (savedItem) {
+      updateStatus(type, itemId, nextStatus);
+      return;
+    }
+
+    saveItem(snapshot, {
+      status: nextStatus,
+      favorite: false,
+    });
+  };
+
+  const handleFavoriteToggle = () => {
+    if (savedItem) {
+      toggleFavorite(type, itemId);
+      return;
+    }
+
+    saveItem(snapshot, {
+      status: currentStatus,
+      favorite: true,
+    });
+  };
+
+  return (
+    <section className="library-controls" aria-label="Library controls">
+      <div className="library-controls__header">
+        <p className="section-kicker">Personal shelf</p>
+        <strong>{savedItem ? "Saved locally" : "Save for offline"}</strong>
+      </div>
+      <div className="library-controls__actions">
+        <button
+          className={savedItem ? "library-controls__button library-controls__button--muted" : "library-controls__button"}
+          type="button"
+          onClick={savedItem ? handleRemove : handleSave}
+        >
+          {savedItem ? "Remove from library" : "Save to library"}
+        </button>
+        <button
+          className={savedItem?.favorite ? "library-controls__favorite library-controls__favorite--active" : "library-controls__favorite"}
+          type="button"
+          aria-pressed={Boolean(savedItem?.favorite)}
+          onClick={handleFavoriteToggle}
+        >
+          {savedItem?.favorite ? "Unmark favorite" : "Mark as favorite"}
+        </button>
+      </div>
+      <label className="library-controls__status">
+        <span>Status</span>
+        <select aria-label="Library status" value={currentStatus} onChange={handleStatusChange}>
+          {Object.entries(labels).map(([value, label]) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
+        </select>
+      </label>
+    </section>
+  );
+};
+
+LibraryControls.propTypes = {
+  item: PropTypes.shape({
+    mal_id: PropTypes.number,
+  }).isRequired,
+  type: PropTypes.oneOf(["anime", "manga"]).isRequired,
+};
+
+export default LibraryControls;

--- a/src/components/LibraryControls/libraryControls.scss
+++ b/src/components/LibraryControls/libraryControls.scss
@@ -1,0 +1,92 @@
+.library-controls {
+  background: rgba(28, 26, 23, 0.78);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  display: grid;
+  gap: 14px;
+  margin-top: 20px;
+  max-width: 520px;
+  padding: 16px;
+}
+
+.library-controls__header {
+  display: grid;
+  gap: 5px;
+
+  strong {
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 850;
+  }
+}
+
+.library-controls__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.library-controls__button,
+.library-controls__favorite {
+  border: 1px solid rgba(217, 164, 65, 0.45);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.92rem;
+  font-weight: 800;
+  min-height: 42px;
+  padding: 10px 13px;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+
+  &:hover {
+    border-color: rgba(217, 164, 65, 0.78);
+    transform: translateY(-1px);
+  }
+}
+
+.library-controls__button {
+  background: rgba(217, 164, 65, 0.18);
+}
+
+.library-controls__button--muted {
+  background: rgba(246, 240, 229, 0.06);
+  border-color: var(--surface-border-strong);
+}
+
+.library-controls__favorite {
+  background: rgba(134, 215, 198, 0.1);
+  border-color: rgba(134, 215, 198, 0.34);
+}
+
+.library-controls__favorite--active {
+  background: rgba(134, 215, 198, 0.2);
+  border-color: rgba(134, 215, 198, 0.68);
+}
+
+.library-controls__status {
+  display: grid;
+  gap: 8px;
+
+  span {
+    color: var(--text-subtle);
+    font-size: 0.72rem;
+    font-weight: 850;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  select {
+    appearance: none;
+    background: rgba(12, 12, 11, 0.72);
+    border: 1px solid var(--surface-border-strong);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    min-height: 44px;
+    padding: 10px 12px;
+
+    &:focus {
+      border-color: rgba(217, 164, 65, 0.78);
+      box-shadow: 0 0 0 4px rgba(217, 164, 65, 0.14);
+      outline: none;
+    }
+  }
+}

--- a/src/features/userLibrary.js
+++ b/src/features/userLibrary.js
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export const USER_LIBRARY_STORAGE_KEY = "animebounty:user-library:v1";
+export const USER_LIBRARY_UPDATED_EVENT = "animebounty:user-library-updated";
+
+export const LIBRARY_STATUSES = ["watching", "planning", "completed", "dropped"];
+
+const DEFAULT_STATUS = "planning";
+
+const getBrowserStorage = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const isValidLibraryItem = (item) => (
+  item &&
+  (item.type === "anime" || item.type === "manga") &&
+  Number.isFinite(Number(item.id)) &&
+  typeof item.title === "string" &&
+  LIBRARY_STATUSES.includes(item.status)
+);
+
+const normalizeStatus = (status) => (
+  LIBRARY_STATUSES.includes(status) ? status : DEFAULT_STATUS
+);
+
+const getItemKey = (type, id) => `${type}:${Number(id)}`;
+
+const readItems = (storage) => {
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const rawItems = storage.getItem(USER_LIBRARY_STORAGE_KEY);
+
+    if (!rawItems) {
+      return [];
+    }
+
+    const parsedItems = JSON.parse(rawItems);
+
+    if (!Array.isArray(parsedItems)) {
+      storage.setItem(USER_LIBRARY_STORAGE_KEY, "[]");
+      return [];
+    }
+
+    return parsedItems.filter(isValidLibraryItem);
+  } catch {
+    try {
+      storage.setItem(USER_LIBRARY_STORAGE_KEY, "[]");
+    } catch {
+      return [];
+    }
+
+    return [];
+  }
+};
+
+const writeItems = (storage, items) => {
+  if (!storage) {
+    return items;
+  }
+
+  try {
+    storage.setItem(USER_LIBRARY_STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    return items;
+  }
+
+  return items;
+};
+
+export const getLibraryItems = (storage = getBrowserStorage()) => readItems(storage);
+
+export const getLibraryItem = (storage = getBrowserStorage(), type, id) => (
+  getLibraryItems(storage).find((item) => item.type === type && Number(item.id) === Number(id)) ?? null
+);
+
+export const createLibrarySnapshot = (source, type) => {
+  const id = Number(source?.mal_id ?? source?.id);
+  const title = source?.title_english || source?.title || source?.title_japanese || "Untitled";
+  const imageUrl =
+    source?.images?.webp?.large_image_url ||
+    source?.images?.webp?.image_url ||
+    source?.imageUrl ||
+    "";
+
+  return {
+    id,
+    type,
+    title,
+    imageUrl,
+    score: source?.score ?? null,
+    route: `/${type}/${id}`,
+  };
+};
+
+export const addOrUpdateLibraryItem = (
+  storage = getBrowserStorage(),
+  snapshot,
+  { status, favorite, now = new Date().toISOString() } = {}
+) => {
+  const items = getLibraryItems(storage);
+  const normalizedSnapshot = {
+    ...snapshot,
+    id: Number(snapshot.id),
+    score: snapshot.score ?? null,
+    imageUrl: snapshot.imageUrl ?? "",
+    route: snapshot.route || `/${snapshot.type}/${Number(snapshot.id)}`,
+  };
+  const existingItem = items.find((item) => (
+    item.type === normalizedSnapshot.type && Number(item.id) === normalizedSnapshot.id
+  ));
+  const nextItem = {
+    ...existingItem,
+    ...normalizedSnapshot,
+    status: normalizeStatus(status ?? existingItem?.status),
+    favorite: favorite ?? existingItem?.favorite ?? false,
+    savedAt: existingItem?.savedAt ?? now,
+    updatedAt: now,
+  };
+  const nextItems = existingItem
+    ? items.map((item) => (getItemKey(item.type, item.id) === getItemKey(nextItem.type, nextItem.id) ? nextItem : item))
+    : [nextItem, ...items];
+
+  return writeItems(storage, nextItems);
+};
+
+export const removeLibraryItem = (storage = getBrowserStorage(), type, id) => {
+  const nextItems = getLibraryItems(storage).filter((item) => (
+    getItemKey(item.type, item.id) !== getItemKey(type, id)
+  ));
+
+  return writeItems(storage, nextItems);
+};
+
+export const updateLibraryStatus = (
+  storage = getBrowserStorage(),
+  type,
+  id,
+  status,
+  { now = new Date().toISOString() } = {}
+) => {
+  const nextItems = getLibraryItems(storage).map((item) => (
+    getItemKey(item.type, item.id) === getItemKey(type, id)
+      ? { ...item, status: normalizeStatus(status), updatedAt: now }
+      : item
+  ));
+
+  return writeItems(storage, nextItems);
+};
+
+export const toggleLibraryFavorite = (
+  storage = getBrowserStorage(),
+  type,
+  id,
+  { now = new Date().toISOString() } = {}
+) => {
+  const nextItems = getLibraryItems(storage).map((item) => (
+    getItemKey(item.type, item.id) === getItemKey(type, id)
+      ? { ...item, favorite: !item.favorite, updatedAt: now }
+      : item
+  ));
+
+  return writeItems(storage, nextItems);
+};
+
+const notifyLibraryUpdated = () => {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(USER_LIBRARY_UPDATED_EVENT));
+  }
+};
+
+export const useUserLibrary = () => {
+  const [items, setItems] = useState(() => getLibraryItems());
+
+  useEffect(() => {
+    const syncItems = () => setItems(getLibraryItems());
+
+    window.addEventListener(USER_LIBRARY_UPDATED_EVENT, syncItems);
+    window.addEventListener("storage", syncItems);
+
+    return () => {
+      window.removeEventListener(USER_LIBRARY_UPDATED_EVENT, syncItems);
+      window.removeEventListener("storage", syncItems);
+    };
+  }, []);
+
+  const saveItem = useCallback((snapshot, options) => {
+    const nextItems = addOrUpdateLibraryItem(getBrowserStorage(), snapshot, options);
+    setItems(nextItems);
+    notifyLibraryUpdated();
+    return nextItems;
+  }, []);
+
+  const removeItem = useCallback((type, id) => {
+    const nextItems = removeLibraryItem(getBrowserStorage(), type, id);
+    setItems(nextItems);
+    notifyLibraryUpdated();
+    return nextItems;
+  }, []);
+
+  const updateStatus = useCallback((type, id, status) => {
+    const nextItems = updateLibraryStatus(getBrowserStorage(), type, id, status);
+    setItems(nextItems);
+    notifyLibraryUpdated();
+    return nextItems;
+  }, []);
+
+  const toggleFavorite = useCallback((type, id) => {
+    const nextItems = toggleLibraryFavorite(getBrowserStorage(), type, id);
+    setItems(nextItems);
+    notifyLibraryUpdated();
+    return nextItems;
+  }, []);
+
+  const getItem = useCallback((type, id) => (
+    items.find((item) => item.type === type && Number(item.id) === Number(id)) ?? null
+  ), [items]);
+
+  return useMemo(() => ({
+    items,
+    getItem,
+    saveItem,
+    removeItem,
+    updateStatus,
+    toggleFavorite,
+  }), [getItem, items, removeItem, saveItem, toggleFavorite, updateStatus]);
+};


### PR DESCRIPTION
## Summary
- Add a local user library route with filters and saved-item cards
- Add save/remove, status, and favorite controls on anime and manga detail pages
- Add storage checks and Playwright coverage for offline library behavior

## Testing
- `library:check` verifies the storage helpers and denial fallback
- Playwright UI coverage validates saving, filtering, and offline rendering