### PR TITLE
Add character profile pages and relation chain navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+test-results
 *.local
 
 # Editor directories and files

--- a/e2e/jikan-endpoints.spec.js
+++ b/e2e/jikan-endpoints.spec.js
@@ -93,6 +93,10 @@ const routeJikan = async (page) => {
       body = {
         data: [
           {
+            relation: 'Prequel',
+            entry: [{ mal_id: 8, type: 'anime', name: 'Relation Prequel Fixture', url: 'https://myanimelist.net/anime/8' }],
+          },
+          {
             relation: 'Sequel',
             entry: [{ mal_id: 9, type: 'anime', name: 'Relation Anime Fixture', url: 'https://myanimelist.net/anime/9' }],
           },
@@ -148,7 +152,7 @@ const routeJikan = async (page) => {
           },
         ],
       };
-    } else if (pathname === '/v4/characters/777') {
+    } else if (pathname === '/v4/characters/777/full') {
       body = {
         data: {
           mal_id: 777,
@@ -156,7 +160,29 @@ const routeJikan = async (page) => {
           name_kanji: 'プロフィール',
           favorites: 1234,
           about: 'A short mocked character biography.',
-          images: { webp: {} },
+          images: { webp: { image_url: 'https://example.com/profile-character.webp' } },
+          anime: [
+            {
+              role: 'Main',
+              anime: {
+                mal_id: 1,
+                title: 'Character Anime Fixture',
+                url: 'https://myanimelist.net/anime/1',
+                images: { webp: {} },
+              },
+            },
+          ],
+          manga: [
+            {
+              role: 'Supporting',
+              manga: {
+                mal_id: 2,
+                title: 'Character Manga Fixture',
+                url: 'https://myanimelist.net/manga/2',
+                images: { webp: {} },
+              },
+            },
+          ],
         },
       };
     }
@@ -199,6 +225,9 @@ test('anime details expose relations, streaming, videos, and character profile o
   await page.goto('/anime/1');
 
   await page.getByRole('button', { name: 'Explore relations' }).click();
+  await expect(page.getByText('Franchise chain')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Prequel' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Relation Prequel Fixture' })).toHaveAttribute('href', '/anime/8');
   await expect(page.getByText('Relation Anime Fixture')).toBeVisible();
 
   await page.getByRole('button', { name: 'Find streams' }).click();
@@ -208,8 +237,8 @@ test('anime details expose relations, streaming, videos, and character profile o
   await expect(page.getByRole('link', { name: 'Promo Fixture' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Browse character list' }).click();
-  await page.getByRole('button', { name: 'Open profile for Profile Character' }).click();
-  await expect(page.getByRole('heading', { name: 'Profile Character' })).toBeVisible();
+  await page.getByRole('link', { name: 'Open profile for Profile Character' }).click();
+  await expect(page).toHaveURL(/\/character\/777$/);
   await expect(page.getByText('A short mocked character biography.')).toBeVisible();
 });
 
@@ -217,9 +246,47 @@ test('manga details expose relations and character profile on demand', async ({ 
   await page.goto('/manga/2');
 
   await page.getByRole('button', { name: 'Explore relations' }).click();
+  await expect(page.getByText('Franchise chain')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Adaptation' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Manga Relation Anime' })).toHaveAttribute('href', '/anime/1');
   await expect(page.getByText('Manga Relation Anime')).toBeVisible();
 
   await page.getByRole('button', { name: 'Browse character list' }).click();
-  await page.getByRole('button', { name: 'Open profile for Profile Character' }).click();
+  await page.getByRole('link', { name: 'Open profile for Profile Character' }).click();
+  await expect(page).toHaveURL(/\/character\/777$/);
   await expect(page.getByRole('heading', { name: 'Profile Character' })).toBeVisible();
+});
+
+test('character page shows biography and anime and manga appearances', async ({ page }) => {
+  await page.goto('/character/777');
+
+  await expect(page.getByRole('heading', { name: 'Profile Character' })).toBeVisible();
+  await expect(page.getByText('プロフィール')).toBeVisible();
+  await expect(page.getByText('A short mocked character biography.')).toBeVisible();
+  await expect(page.getByRole('link', { name: /Character Anime Fixture/ })).toHaveAttribute('href', '/anime/1');
+  await expect(page.getByRole('link', { name: /Character Manga Fixture/ })).toHaveAttribute('href', '/manga/2');
+});
+
+test('character page tolerates missing nested fields', async ({ page }) => {
+  await page.route('https://api.jikan.moe/v4/characters/999/full', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          mal_id: 999,
+          name: 'Sparse Character Fixture',
+          images: {},
+          anime: null,
+          manga: null,
+        },
+      }),
+    });
+  });
+
+  await page.goto('/character/999');
+
+  await expect(page.getByRole('heading', { name: 'Sparse Character Fixture' })).toBeVisible();
+  await expect(page.getByText('No character biography is available yet.')).toBeVisible();
+  await expect(page.getByText('No anime appearances are listed yet.')).toBeVisible();
+  await expect(page.getByText('No manga appearances are listed yet.')).toBeVisible();
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import './App.scss';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
 import FullAnime from './components/FullAnime/FullAnime';
+import CharacterPage from './components/CharacterPage/CharacterPage';
 import Anime from './Page/Anime';
 import Manga from './Page/Manga';
 import FullManga from './components/FullManga/FullManga';
@@ -18,6 +19,7 @@ const App = () => {
           <Route path="/" element={<GeneralPage />} />
           <Route path="/anime" element={<Anime />} />
           <Route path="/anime/:id" element={<FullAnime />} />
+          <Route path="/character/:id" element={<CharacterPage />} />
           <Route path="/manga" element={<Manga />} />
           <Route path="/manga/:id" element={<FullManga />} />
           <Route path="/library" element={<Library />} />

--- a/src/components/CharacterPage/CharacterPage.jsx
+++ b/src/components/CharacterPage/CharacterPage.jsx
@@ -1,0 +1,195 @@
+import { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
+import PropTypes from "prop-types";
+import ErrorState from "../ErrorState/ErrorState";
+import LazyLoading from "../LazyLoading/LazyLoading";
+import { useGetCharacterFullQuery } from "../../features/apiSlice";
+import "./CharacterPage.scss";
+
+const getImageUrl = (item) => (
+  item?.images?.webp?.large_image_url ||
+  item?.images?.webp?.image_url ||
+  item?.images?.jpg?.large_image_url ||
+  item?.images?.jpg?.image_url
+);
+
+const getInternalTarget = (type, item) => {
+  if (!item?.mal_id) {
+    return null;
+  }
+
+  return `/${type}/${item.mal_id}`;
+};
+
+const AppearanceCard = ({ appearance, type }) => {
+  const item = appearance?.[type] ?? {};
+  const title = item.title || `Untitled ${type}`;
+  const imageUrl = getImageUrl(item);
+  const internalTarget = getInternalTarget(type, item);
+  const className = "character-page__appearance-card";
+  const content = (
+    <>
+      <div className="character-page__appearance-media">
+        {imageUrl ? <img src={imageUrl} alt="" /> : <span>{type}</span>}
+      </div>
+      <div className="character-page__appearance-copy">
+        <span>{appearance?.role || "Role unknown"}</span>
+        <strong>{title}</strong>
+      </div>
+    </>
+  );
+
+  return internalTarget ? (
+    <Link className={className} to={internalTarget}>
+      {content}
+    </Link>
+  ) : (
+    <a className={className} href={item.url || "#"} target="_blank" rel="noreferrer">
+      {content}
+    </a>
+  );
+};
+
+const AppearanceSection = ({ items, title, emptyMessage, type }) => {
+  const appearances = Array.isArray(items) ? items : [];
+
+  return (
+    <section className="character-page__section" aria-labelledby={`${type}-appearances-title`}>
+      <div className="character-page__section-header">
+        <p className="section-kicker">{type}ography</p>
+        <h2 id={`${type}-appearances-title`} className="detail-section__title">{title}</h2>
+      </div>
+      {appearances.length > 0 ? (
+        <div className="character-page__appearance-grid">
+          {appearances.map((appearance) => {
+            const item = appearance?.[type] ?? {};
+            const key = `${type}-${item.mal_id || item.title || appearance?.role}`;
+
+            return <AppearanceCard key={key} appearance={appearance} type={type} />;
+          })}
+        </div>
+      ) : (
+        <p className="detail-empty">{emptyMessage}</p>
+      )}
+    </section>
+  );
+};
+
+const CharacterPage = () => {
+  const { id } = useParams();
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetCharacterFullQuery(id);
+  const character = data?.data;
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [id]);
+
+  if (isLoading) {
+    return (
+      <main className="character-page">
+        <div className="container">
+          <LazyLoading message="Loading character profile..." count={6} />
+        </div>
+      </main>
+    );
+  }
+
+  if (isError) {
+    return (
+      <main className="character-page">
+        <div className="container">
+          <ErrorState
+            message="Character profile could not be loaded."
+            onRetry={refetch}
+            isRetrying={isFetching}
+          />
+        </div>
+      </main>
+    );
+  }
+
+  if (!character) {
+    return (
+      <main className="character-page">
+        <div className="container">
+          <ErrorState message="Character profile is empty." />
+        </div>
+      </main>
+    );
+  }
+
+  const characterName = character.name || "Unknown character";
+  const characterImageUrl = getImageUrl(character);
+  const nicknames = Array.isArray(character.nicknames) ? character.nicknames : [];
+
+  return (
+    <main className="character-page">
+      <div className="container">
+        <section className="character-page__hero">
+          <div className="character-page__portrait">
+            {characterImageUrl ? <img src={characterImageUrl} alt={characterName} /> : <span>No image</span>}
+          </div>
+          <div className="character-page__intro">
+            <p className="section-kicker">Character profile</p>
+            <h1>{characterName}</h1>
+            {character.name_kanji ? <p className="character-page__kanji">{character.name_kanji}</p> : null}
+            <div className="character-page__meta">
+              <span>Favorites</span>
+              <strong>{character.favorites ?? "Unknown"}</strong>
+            </div>
+            {nicknames.length > 0 ? (
+              <div className="character-page__nicknames">
+                {nicknames.slice(0, 4).map((nickname) => (
+                  <span key={nickname}>{nickname}</span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="character-page__section" aria-labelledby="character-biography-title">
+          <div className="character-page__section-header">
+            <p className="section-kicker">Biography</p>
+            <h2 id="character-biography-title" className="detail-section__title">About</h2>
+          </div>
+          <p className="character-page__biography">
+            {character.about || "No character biography is available yet."}
+          </p>
+        </section>
+
+        <AppearanceSection
+          emptyMessage="No anime appearances are listed yet."
+          items={character.anime}
+          title="Anime appearances"
+          type="anime"
+        />
+        <AppearanceSection
+          emptyMessage="No manga appearances are listed yet."
+          items={character.manga}
+          title="Manga appearances"
+          type="manga"
+        />
+      </div>
+    </main>
+  );
+};
+
+AppearanceCard.propTypes = {
+  appearance: PropTypes.object,
+  type: PropTypes.oneOf(["anime", "manga"]).isRequired,
+};
+
+AppearanceSection.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object),
+  title: PropTypes.string.isRequired,
+  emptyMessage: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(["anime", "manga"]).isRequired,
+};
+
+export default CharacterPage;

--- a/src/components/CharacterPage/CharacterPage.scss
+++ b/src/components/CharacterPage/CharacterPage.scss
@@ -1,0 +1,175 @@
+.character-page {
+  padding: clamp(28px, 5vw, 56px) 0 64px;
+}
+
+.character-page__hero,
+.character-page__section {
+  background: rgba(28, 26, 23, 0.72);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  margin-top: 24px;
+  padding: clamp(18px, 3vw, 30px);
+}
+
+.character-page__hero {
+  display: grid;
+  gap: clamp(20px, 4vw, 36px);
+  grid-template-columns: minmax(180px, 280px) minmax(0, 1fr);
+  margin-top: 0;
+}
+
+.character-page__portrait {
+  align-items: center;
+  aspect-ratio: 3 / 4;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-subtle);
+  display: flex;
+  font-weight: 850;
+  justify-content: center;
+  overflow: hidden;
+  text-transform: uppercase;
+}
+
+.character-page__portrait img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.character-page__intro {
+  align-self: center;
+  min-width: 0;
+}
+
+.character-page__intro h1 {
+  color: var(--text-primary);
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 950;
+  line-height: 1;
+  margin-top: 8px;
+}
+
+.character-page__kanji {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  margin-top: 10px;
+}
+
+.character-page__meta {
+  align-items: center;
+  border-top: 1px solid var(--surface-border);
+  display: flex;
+  gap: 12px;
+  margin-top: 22px;
+  padding-top: 18px;
+}
+
+.character-page__meta span,
+.character-page__appearance-copy span {
+  color: var(--text-subtle);
+  font-size: 0.78rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.character-page__meta strong {
+  color: var(--accent);
+  font-size: 1.15rem;
+}
+
+.character-page__nicknames {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.character-page__nicknames span {
+  background: rgba(134, 215, 198, 0.1);
+  border: 1px solid rgba(134, 215, 198, 0.36);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-weight: 800;
+  padding: 7px 10px;
+}
+
+.character-page__section-header {
+  margin-bottom: 16px;
+}
+
+.character-page__biography {
+  color: var(--text-muted);
+  line-height: 1.75;
+  white-space: pre-line;
+}
+
+.character-page__appearance-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.character-page__appearance-card {
+  align-items: center;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 42%), var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 74px minmax(0, 1fr);
+  min-height: 104px;
+  padding: 12px;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.character-page__appearance-card:hover {
+  background: rgba(134, 215, 198, 0.1);
+  border-color: rgba(134, 215, 198, 0.48);
+  transform: translateY(-1px);
+}
+
+.character-page__appearance-media {
+  align-items: center;
+  aspect-ratio: 3 / 4;
+  background: var(--surface-strong);
+  border-radius: var(--radius);
+  color: var(--text-subtle);
+  display: flex;
+  font-size: 0.72rem;
+  font-weight: 900;
+  justify-content: center;
+  overflow: hidden;
+  text-transform: uppercase;
+}
+
+.character-page__appearance-media img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.character-page__appearance-copy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.character-page__appearance-copy strong {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+@media (max-width: 820px) {
+  .character-page__hero,
+  .character-page__appearance-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .character-page__portrait {
+    max-width: 280px;
+  }
+}

--- a/src/components/FullAnime/FullAnime.jsx
+++ b/src/components/FullAnime/FullAnime.jsx
@@ -8,7 +8,6 @@ import ReviewCard from "../ReviewCard/ReviewCard";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
 import {
-  CharacterProfilePanel,
   RelationsPanel,
   StreamingPanel,
   VideosPanel,
@@ -26,7 +25,6 @@ import {
   useLazyGetAnimeCharactersQuery,
   useLazyGetAnimeStreamingQuery,
   useLazyGetAnimeVideosQuery,
-  useLazyGetCharacterFullQuery,
   useLazyGetAnimeReviewsQuery,
 } from "../../features/apiSlice";
 
@@ -60,7 +58,6 @@ const FullAnime = () => {
   const [isActiveRelations, setIsActiveRelations] = useState(false)
   const [isActiveStreaming, setIsActiveStreaming] = useState(false)
   const [isActiveVideos, setIsActiveVideos] = useState(false)
-  const [selectedCharacter, setSelectedCharacter] = useState(null)
   const {
     data: fullAnimeData,
     isLoading: fullAnimeLoading,
@@ -121,15 +118,6 @@ const FullAnime = () => {
       isError: animeVideosError,
     },
   ] = useLazyGetAnimeVideosQuery()
-  const [
-    triggerCharacterFull,
-    {
-      data: characterFull,
-      isLoading: characterFullLoading,
-      isFetching: characterFullFetching,
-      isError: characterFullError,
-    },
-  ] = useLazyGetCharacterFullQuery()
   const [
     triggerAnimeReviews,
     {
@@ -204,20 +192,6 @@ const FullAnime = () => {
       triggerAnimeVideos(id, true);
     }
   };
-  const handleShowCharacterProfile = (character) => {
-    const characterId = character?.mal_id;
-
-    if (!characterId) {
-      return;
-    }
-
-    setSelectedCharacter({
-      id: characterId,
-      name: character?.name || "Unknown",
-    });
-    triggerCharacterFull(characterId, true);
-  };
-
   return (
     <div className="fullAnime__wrapper pb-10">
       <div className="container">
@@ -385,27 +359,22 @@ const FullAnime = () => {
                           {voiceActors.slice(0, 2).map(actor => (
                             <p key={actor.person?.mal_id || `${actor.language}-${actor.person?.name}`}>{actor.language || "Unknown"} : <b>{actor.person?.name || "Unknown"}</b></p>
                           ))}
-                          <button
-                            type="button"
-                            className="character-profile-button"
-                            onClick={() => handleShowCharacterProfile(character)}
-                          >
-                            Open profile for {characterName}
-                          </button>
+                          {character?.mal_id ? (
+                            <Link
+                              className="character-profile-button"
+                              to={`/character/${character.mal_id}`}
+                            >
+                              Open profile for {characterName}
+                            </Link>
+                          ) : (
+                            <p className="detail-empty">Character profile is not available.</p>
+                          )}
                         </div>
                       </div>
                     );
                   })}
                 </div>
               ) : isActiveCharacters ? <p>There are currently no characters for this anime.</p> : null}
-              <CharacterProfilePanel
-                characterName={selectedCharacter?.name}
-                data={characterFull}
-                isError={characterFullError}
-                isFetching={characterFullFetching}
-                isLoading={characterFullLoading}
-                onRetry={() => triggerCharacterFull(selectedCharacter?.id, false)}
-              />
             </div>
             <div className="reviews mt-5">
               <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowAnimeReviews}>Read community reviews</button>

--- a/src/components/FullManga/FullManga.jsx
+++ b/src/components/FullManga/FullManga.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import "swiper/css";
 import "swiper/css/autoplay";
 import "./FullManga.scss";
@@ -9,7 +9,6 @@ import LazyLoading from "../LazyLoading/LazyLoading";
 import ErrorState from "../ErrorState/ErrorState";
 import ReviewCard from "../ReviewCard/ReviewCard";
 import {
-  CharacterProfilePanel,
   RelationsPanel,
 } from "../JikanDetailExtras/JikanDetailExtras";
 import LibraryControls from "../LibraryControls/LibraryControls";
@@ -20,7 +19,6 @@ import {
   useGetMangaPicturesQuery,
   useLazyGetMangaCharactersQuery,
   useLazyGetMangaRelationsQuery,
-  useLazyGetCharacterFullQuery,
   useLazyGetMangaReviewsQuery,
 } from "../../features/apiSlice";
 
@@ -51,7 +49,6 @@ const FullManga = () => {
   const [isActiveCharacters, setIsActiveCharacters] = useState(false);
   const [isActiveReviews, setIsActiveReviews] = useState(false)
   const [isActiveRelations, setIsActiveRelations] = useState(false)
-  const [selectedCharacter, setSelectedCharacter] = useState(null)
   const { id } = useParams();
 
   const {
@@ -89,15 +86,6 @@ const FullManga = () => {
       isError: mangaRelationsError,
     },
   ] = useLazyGetMangaRelationsQuery()
-  const [
-    triggerCharacterFull,
-    {
-      data: characterFull,
-      isLoading: characterFullLoading,
-      isFetching: characterFullFetching,
-      isError: characterFullError,
-    },
-  ] = useLazyGetCharacterFullQuery()
   const [
     triggerMangaReviews,
     {
@@ -153,20 +141,6 @@ const FullManga = () => {
       triggerMangaRelations(id, true);
     }
   };
-  const handleShowCharacterProfile = (character) => {
-    const characterId = character?.mal_id;
-
-    if (!characterId) {
-      return;
-    }
-
-    setSelectedCharacter({
-      id: characterId,
-      name: character?.name || "Unknown",
-    });
-    triggerCharacterFull(characterId, true);
-  };
-
   return (
     <div className="fullManga__wrapper pb-10">
       {fullMangaLoading ? (
@@ -268,27 +242,22 @@ const FullManga = () => {
                       <div className="mangaCharacters__card-textWrapepr p-2">
                         <p className="mangaCharacters__card-text">Name : <b>{characterName}</b></p>
                         <p className="mangaCharacters__card-subText">Role: <b>{obj.role || "Unknown"}</b></p>
-                        <button
-                          type="button"
-                          className="character-profile-button"
-                          onClick={() => handleShowCharacterProfile(character)}
-                        >
-                          Open profile for {characterName}
-                        </button>
+                        {character?.mal_id ? (
+                          <Link
+                            className="character-profile-button"
+                            to={`/character/${character.mal_id}`}
+                          >
+                            Open profile for {characterName}
+                          </Link>
+                        ) : (
+                          <p className="detail-empty">Character profile is not available.</p>
+                        )}
                       </div>
                     </div>
                   );
                 })}
               </div>
             ) : isActiveCharacters ? <p>There are currently no characters for this manga.</p> : null}
-            <CharacterProfilePanel
-              characterName={selectedCharacter?.name}
-              data={characterFull}
-              isError={characterFullError}
-              isFetching={characterFullFetching}
-              isLoading={characterFullLoading}
-              onRetry={() => triggerCharacterFull(selectedCharacter?.id, false)}
-            />
           </div>
           <div className="reviews mt-5">
             <button className={isActiveReviews ? "display-none" : 'show-btn bg-black text-white py-2 px-3'} onClick={handleShowMangaReviews}>Read community reviews</button>

--- a/src/components/JikanDetailExtras/JikanDetailExtras.jsx
+++ b/src/components/JikanDetailExtras/JikanDetailExtras.jsx
@@ -4,8 +4,30 @@ import ErrorState from "../ErrorState/ErrorState";
 import LazyLoading from "../LazyLoading/LazyLoading";
 import "./jikanDetailExtras.scss";
 
+const relationPriority = [
+  "Prequel",
+  "Sequel",
+  "Spin-off",
+  "Side story",
+  "Adaptation",
+  "Alternative version",
+  "Alternative setting",
+  "Parent story",
+  "Summary",
+  "Character",
+  "Other",
+];
+
+const getRelationRank = (relation) => {
+  const index = relationPriority.findIndex((item) => item.toLowerCase() === relation?.toLowerCase());
+
+  return index === -1 ? relationPriority.length : index;
+};
+
 export const RelationsPanel = ({ isActive, isError, isFetching, isLoading, items, onOpen, onRetry }) => {
-  const relationItems = Array.isArray(items) ? items : [];
+  const relationItems = Array.isArray(items)
+    ? [...items].sort((first, second) => getRelationRank(first.relation) - getRelationRank(second.relation))
+    : [];
 
   return (
     <section className="detail-extra" aria-labelledby="relations-title">
@@ -26,28 +48,32 @@ export const RelationsPanel = ({ isActive, isError, isFetching, isLoading, items
         ) : isError ? (
           <ErrorState message="Relations could not be loaded." onRetry={onRetry} isRetrying={isFetching} />
         ) : relationItems.length > 0 ? (
-          <div className="detail-extra__relation-grid">
+          <div className="detail-extra__relation-chain" aria-label="Franchise chain">
+            <p className="detail-extra__chain-label">Franchise chain</p>
             {relationItems.map((relation) => {
               const entries = Array.isArray(relation.entry) ? relation.entry : [];
 
               return (
-                <article key={relation.relation} className="detail-extra__relation-card">
-                  <h3>{relation.relation || "Related"}</h3>
-                  <div className="detail-extra__links">
-                    {entries.map((entry) => {
-                      const isInternal = entry.type === "anime" || entry.type === "manga";
-                      const target = isInternal ? `/${entry.type}/${entry.mal_id}` : entry.url;
+                <article key={relation.relation} className="detail-extra__relation-step">
+                  <div className="detail-extra__relation-marker" aria-hidden="true" />
+                  <div className="detail-extra__relation-card">
+                    <h3>{relation.relation || "Related"}</h3>
+                    <div className="detail-extra__links">
+                      {entries.map((entry) => {
+                        const isInternal = entry.type === "anime" || entry.type === "manga";
+                        const target = isInternal ? `/${entry.type}/${entry.mal_id}` : entry.url;
 
-                      return isInternal ? (
-                        <Link key={`${entry.type}-${entry.mal_id}-${entry.name}`} to={target}>
-                          {entry.name || "Untitled relation"}
-                        </Link>
-                      ) : (
-                        <a key={`${entry.type}-${entry.mal_id}-${entry.name}`} href={target} target="_blank" rel="noreferrer">
-                          {entry.name || "Untitled relation"}
-                        </a>
-                      );
-                    })}
+                        return isInternal ? (
+                          <Link key={`${entry.type}-${entry.mal_id}-${entry.name}`} to={target}>
+                            {entry.name || "Untitled relation"}
+                          </Link>
+                        ) : (
+                          <a key={`${entry.type}-${entry.mal_id}-${entry.name}`} href={target} target="_blank" rel="noreferrer">
+                            {entry.name || "Untitled relation"}
+                          </a>
+                        );
+                      })}
+                    </div>
                   </div>
                 </article>
               );

--- a/src/components/JikanDetailExtras/jikanDetailExtras.scss
+++ b/src/components/JikanDetailExtras/jikanDetailExtras.scss
@@ -24,6 +24,52 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.detail-extra__relation-chain {
+  display: grid;
+  gap: 0;
+  position: relative;
+}
+
+.detail-extra__chain-label {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  font-weight: 800;
+  margin-bottom: 14px;
+}
+
+.detail-extra__relation-step {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 24px minmax(0, 1fr);
+  position: relative;
+}
+
+.detail-extra__relation-step:not(:last-child) {
+  padding-bottom: 14px;
+}
+
+.detail-extra__relation-step:not(:last-child)::before {
+  background: rgba(217, 164, 65, 0.34);
+  bottom: 0;
+  content: "";
+  left: 9px;
+  position: absolute;
+  top: 20px;
+  width: 2px;
+}
+
+.detail-extra__relation-marker {
+  background: var(--accent);
+  border: 4px solid rgba(28, 26, 23, 0.95);
+  border-radius: 999px;
+  box-shadow: 0 0 0 1px rgba(217, 164, 65, 0.5);
+  height: 20px;
+  margin-top: 16px;
+  position: relative;
+  width: 20px;
+  z-index: 1;
+}
+
 .detail-extra__relation-card,
 .detail-extra__video-card {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 42%), var(--surface);
@@ -127,11 +173,13 @@
   border: 1px solid rgba(134, 215, 198, 0.5);
   border-radius: var(--radius);
   color: var(--text-primary);
+  display: block;
   font-size: 0.88rem;
   font-weight: 850;
   margin-top: 12px;
   min-height: 38px;
   padding: 8px 10px;
+  text-align: center;
   width: 100%;
 }
 
@@ -148,5 +196,9 @@
   .detail-extra__relation-grid,
   .detail-extra__video-grid {
     grid-template-columns: 1fr;
+  }
+
+  .detail-extra__relation-step {
+    grid-template-columns: 20px minmax(0, 1fr);
   }
 }

--- a/src/features/apiSlice.js
+++ b/src/features/apiSlice.js
@@ -136,7 +136,7 @@ export const fetchDataApi = createApi({
       query: (id) => `/manga/${id}/relations`,
     }),
     getCharacterFull: builder.query({
-      query: (id) => `/characters/${id}`,
+      query: (id) => `/characters/${id}/full`,
     }),
 
   })
@@ -183,5 +183,6 @@ export const {
   useLazyGetAnimeStreamingQuery,
   useLazyGetAnimeVideosQuery,
   useLazyGetMangaRelationsQuery,
+  useGetCharacterFullQuery,
   useLazyGetCharacterFullQuery,
 } = fetchDataApi;


### PR DESCRIPTION
## Summary
- Add a dedicated character detail route backed by Jikan full character data, including biography, aliases, favorites, and anime/manga appearances.
- Convert anime and manga character entries into links to the new character page instead of inline profile popups.
- Improve relation rendering with a ranked franchise-chain layout and updated styling.
- Expand Playwright coverage for anime, manga, and character detail flows, including sparse-data handling.
- Ignore Playwright `test-results` artifacts in git.

## Testing
- `npm run verify` passed end to end after rerunning the Playwright smoke suite with local preview server access.
- Playwright coverage now exercises the new character page and the updated relation/navigation behavior.